### PR TITLE
FIX: fix lastReportDate updating logic for all fetching channels

### DIFF
--- a/backend/fetching/channels/cloudflare.js
+++ b/backend/fetching/channels/cloudflare.js
@@ -43,12 +43,20 @@ class CloudflareChannel extends PollChannel {
         this.fetchToTimestamp = fetchToUTCTime.toISOString().split('.')[0] + 'Z'; 
         this.fetchFromTimestamp = fetchFromUTCTime.toISOString().split('.')[0] + 'Z';  
         this.fetchResultLimit = options.fetchResultLimit || CloudflareChannel.LIMIT;
-       
+        
     }
 
     async fetch() {
         
         const outages = [];
+
+        const fetchToUTCTime = new Date(Date.now());
+        const fetchFromUTCTime = new Date(Math.min(Date.parse(this.fetchFromTimestamp), fetchToUTCTime - 2 * 60 * 60 * 1000))
+
+
+        this.fetchToTimestamp = fetchToUTCTime.toISOString().split('.')[0] + 'Z'; 
+        this.fetchFromTimestamp = fetchFromUTCTime.toISOString().split('.')[0] + 'Z';  
+
 
         // Construct query url
         const url = new URL(API_ROUTES.CLOUDFLARE.TRAFFIC_ANOMALIES, API_BASE_URLS.CLOUDFLARE);
@@ -155,7 +163,8 @@ class CloudflareChannel extends PollChannel {
             console.error(`[Fetching-channel-Cloudflare] Failed - Failed parsing and formating data: ${this.options.media}.`);
         }
 
-        const updatedTimestamp = new Date(this.fetchToTimestamp);
+        this.fetchFromTimestamp = this.fetchToTimestamp;
+        const updatedTimestamp = new Date(this.fetchFromTimestamp);
         if (typeof this.options?.onFetch === 'function') {
             await this.options.onFetch(updatedTimestamp);
         }

--- a/backend/fetching/channels/ioda.js
+++ b/backend/fetching/channels/ioda.js
@@ -36,6 +36,13 @@ class IODAChannel extends PollChannel {
         this.interval = options.interval || IODAChannel.INTERVAL;
 
         // Fetch time range from 2H ago (or an earlier timestamp if specified) till now
+        // this.lastFetchedTo =  new Date(); 
+        // if (options.lastTimestamp) {
+        //     const provided = new Date(options.lastTimestamp);
+        //     const fallback = new Date(Date.now() - 2 * 60 * 60 * 1000); // 2h ago
+        //     this.lastFetchedTo = new Date(Math.min(provided, fallback));
+        // }
+  
         this.fetchToTimestamp = Math.floor(Date.now() / 1000); 
 
         this.fetchFromTimestamp = options.lastTimestamp
@@ -45,6 +52,7 @@ class IODAChannel extends PollChannel {
               )
             : this.fetchToTimestamp - 2 * 60 * 60
         
+
         
     }   
 
@@ -78,6 +86,11 @@ class IODAChannel extends PollChannel {
 
     async fetch() {
         const outages = [];
+        
+        // update fetchTo timestamp for each fetch
+        this.fetchToTimestamp = Math.floor(Date.now() / 1000); 
+        this.fetchFromTimestamp = Math.min(this.fetchFromTimestamp, this.fetchToTimestamp - 2 * 60 * 60);
+
 
         for (const queryType of this.queryTypes) {
             try {
@@ -204,7 +217,10 @@ class IODAChannel extends PollChannel {
             }
         }
 
-        const updatedTimestamp = new Date(this.fetchToTimestamp * 1000);
+        
+        // update latestReportDate
+        this.fetchFromTimestamp = this.fetchToTimestamp;
+        const updatedTimestamp = new Date(this.fetchFromTimestamp * 1000);
         if (typeof this.options?.onFetch === 'function') {
             await this.options.onFetch(updatedTimestamp);
         }


### PR DESCRIPTION
### WHAT
A bug fix PR to fix issue that under prod env, lastReportDate's updating logic was incorrect for all fetching channels

### WHY
bug fix, previous lastReportDate updating logic did not rolling updates, but remaining unchanged once fetching channel initialized

### CHANGE

1. fix for all channels under fetching/channels
2. update  new fetchFromTimestamp =  last fetch's fetchTotimestamp, with fallback logic to a minimum 2 hours rolling update window 