### PR TITLE
[frontend] Feat: overall incident status

### DIFF
--- a/backend/models/group.js
+++ b/backend/models/group.js
@@ -74,14 +74,10 @@ let schema = new mongoose.Schema({
   creator: { type: mongoose.Schema.ObjectId, ref: 'User', index: 1 },
   status: { type: String, default: 'new', required: true },
   verification_status: {
-    type: Boolean, 
-    default: false,
-    required: true,
+    type: Boolean,
   },
   confirmation_status: {
-    type: Boolean, 
-    default: false,
-    required: true,
+    type: Boolean,
   },
   publication_status: {
     type: [String],

--- a/src/components/FormikDropdown.tsx
+++ b/src/components/FormikDropdown.tsx
@@ -13,8 +13,9 @@ interface IProps {
   name: string;
   list: { _id: string; label: string }[];
   disabled?: boolean;
+  placeholder?: string;
 }
-const FormikDropdown = ({ label, name, list, disabled = false }: IProps) => {
+const FormikDropdown = ({ label, name, list, disabled = false, placeholder }: IProps) => {
   const [field, meta, helpers] = useField(name);
   const { value } = meta;
   const { onBlur } = field;
@@ -36,7 +37,7 @@ const FormikDropdown = ({ label, name, list, disabled = false }: IProps) => {
           }`}
         >
           <Listbox.Button className='px-3 py-2 focus-theme flex justify-between items-center bg-slate-50 border border-slate-300 w-full hover:bg-slate-100 text-left ui-active:bg-slate-200 rounded'>
-            {list.find((i) => value === i._id)?.label || "Select " + label}
+            {list.find((i) => String(value) === i._id)?.label || placeholder || "Select " + label}
             <FontAwesomeIcon
               icon={faChevronDown}
               className='ui-active:rotate-180 text-slate-400'

--- a/src/pages/incidents/CreateEditIncidentForm.tsx
+++ b/src/pages/incidents/CreateEditIncidentForm.tsx
@@ -17,8 +17,8 @@ const incidentSchema = Yup.object().shape({
   locationName: Yup.string(),
   escalated: Yup.boolean(),
   closed: Yup.boolean(),
-  verification_status: Yup.boolean().required("verification status required"),
-  confirmation_status: Yup.boolean().required("confirmation status required"),
+  verification_status: Yup.boolean(),
+  confirmation_status: Yup.boolean(),
   publication_status: Yup.array(Yup.string())
     .required("publication status required").min(1).max(2)
     .test(
@@ -60,8 +60,8 @@ const CreateEditIncidentForm = ({
           locationName: group?.locationName || "",
           escalated: group?.escalated || false,
           closed: group?.closed || false,
-          verification_status: group?.verification_status || false,
-          confirmation_status: group?.confirmation_status || false,
+          verification_status: group?.verification_status,
+          confirmation_status: group?.confirmation_status,
           publication_status: group?.publication_status || ["Not Published"],
           assignedTo: group?.assignedTo?.map((i) => i._id) || [],
           notes: group?.notes || "",
@@ -85,8 +85,18 @@ const CreateEditIncidentForm = ({
           Ideally, titles should be written as a<i>question</i> that can be
           answered with a true/false
         </p>
-        <FormikSwitch name='verification_status' label='Outage verified?' />
-        <FormikSwitch name='confirmation_status' label='Reason confirmed?' />
+        <FormikDropdown
+          name='verification_status'
+          label='Outage verified?'
+          list={[{_id: "true", label: "Verified"}, {_id: "false", label: "Unable to Verify"}]}
+          placeholder='Verifying'
+        />
+        <FormikDropdown
+          name='confirmation_status'
+          label='Reason confirmed?'
+          list={[{_id: "true", label: "Confirmed"}, {_id: "false", label: "Unable to Confirm"}]}
+          placeholder='Confirming'
+        />
         <FormikMultiCombobox
           name='publication_status'
           unitLabel='status'

--- a/src/pages/incidents/Incident/IncidentInfo.tsx
+++ b/src/pages/incidents/Incident/IncidentInfo.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import {
   faCompass,
   faFileLines,
@@ -10,12 +11,14 @@ import {
   faWarning,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { isNil } from "lodash";
 import { Group } from "../../../api/groups/types";
 import AggieButton from "../../../components/AggieButton";
 import PlaceholderDiv from "../../../components/PlaceholderDiv";
 import TagsList from "../../../components/Tags/TagsList";
 import UserToken from "../../../components/UserToken";
 //import VeracityToken from "../../../components/VeracityToken";
+import incidentOverallStatus from "../incidentOverallStatus";
 
 interface IProps {
   group?: Group;
@@ -23,6 +26,8 @@ interface IProps {
   onEdit: () => void;
 }
 const IncidentInfo = ({ group, isLoading, onEdit }: IProps) => {
+  const [isStatusClicked, setIsStatusClicked] = useState(false);
+  const [isStatusHovered, setIsStatusHovered] = useState(false);
   function isoToYMD (iso : string | Date) {
     if (!iso) return "Unknown Date";
     const date = (iso instanceof Date) ? iso : new Date(iso);
@@ -78,20 +83,47 @@ const IncidentInfo = ({ group, isLoading, onEdit }: IProps) => {
         </div>
       </div>
       <div className='flex gap-2'>
-        <PlaceholderDiv as='p' loading={isLoading} width='7em'
-          className='px-2 py-1 rounded-full bg-teal-200'>
-          {group?.verification_status ? "Verified" : "Unverified"}
-        </PlaceholderDiv>
-        <PlaceholderDiv as='p' loading={isLoading} width='7em'
-          className='px-2 py-1 rounded-full bg-pink-200'>
-          {group?.confirmation_status ? "Confirmed" : "Unconfirmed"}
-        </PlaceholderDiv>
-        {group?.publication_status?.map((s: String) =>
-          <PlaceholderDiv as='p' loading={isLoading} width='7em'
-            className='px-2 py-1 rounded-full bg-fuchsia-200'>
-            {s}
-          </PlaceholderDiv>
-        )}
+        {
+          group && (
+            <PlaceholderDiv as='p' loading={isLoading} width='7em'
+              className='px-2 py-1 rounded-full bg-purple-300 hover:cursor-pointer'
+              onClick={() => setIsStatusClicked(!isStatusClicked)}
+              onMouseEnter={() => setIsStatusHovered(true)}
+              onMouseLeave={() => setIsStatusHovered(false || isStatusClicked)}>
+              {incidentOverallStatus(group)}
+            </PlaceholderDiv>
+          )
+        }
+        {
+          isStatusHovered && (<>
+            <PlaceholderDiv as='p' loading={isLoading} width='7em'
+              className='px-2 py-1 rounded-full bg-fuchsia-200'>
+              {
+                isNil(group?.verification_status)
+                ? "Verifying"
+                : group?.verification_status
+                  ? "Verified"
+                  : "Unable to Verify"
+              }
+            </PlaceholderDiv>
+            <PlaceholderDiv as='p' loading={isLoading} width='7em'
+              className='px-2 py-1 rounded-full bg-fuchsia-200'>
+              {
+                isNil(group?.confirmation_status)
+                ? "Confirming"
+                : group?.confirmation_status
+                  ? "Confirmed"
+                  : "Unable to Confirm"
+              }
+            </PlaceholderDiv>
+            {group?.publication_status?.map((s: String) =>
+              <PlaceholderDiv as='p' loading={isLoading} width='7em'
+                className='px-2 py-1 rounded-full bg-fuchsia-200'>
+                {s}
+              </PlaceholderDiv>
+            )}
+          </>)
+        }
       </div>
       <div className='flex gap-12 my-2'>
         <PlaceholderDiv as='p' width='7em' loading={isLoading}>

--- a/src/pages/incidents/IncidentListItem.tsx
+++ b/src/pages/incidents/IncidentListItem.tsx
@@ -33,6 +33,7 @@ import {
   faFileLines,
   faMessage,
 } from "@fortawesome/free-regular-svg-icons";
+import incidentOverallStatus from "./incidentOverallStatus";
 import UserToken from "../../components/UserToken";
 import { isString } from "lodash";
 import { hasId } from "../../api/common";
@@ -120,9 +121,9 @@ const IncidentListItem = ({ item }: IProps) => {
               {item.title}{" "}
             </span>
             {item.escalated && (
-              <span className='px-1 bg-orange-700/90  text-white font-medium text-sm inline-flex gap-1 items-center no-underline w-fit'>
-                <FontAwesomeIcon icon={faWarning} />
-                Escalated
+              <span
+              className='px-1 py-1 bg-purple-300 rounded-full font-medium text-sm text-slate-600 inline-flex gap-1 items-center no-underline w-fit'>
+                {incidentOverallStatus(item)}
               </span>
             )}
           </h2>

--- a/src/pages/incidents/IncidentListItem.tsx
+++ b/src/pages/incidents/IncidentListItem.tsx
@@ -120,12 +120,10 @@ const IncidentListItem = ({ item }: IProps) => {
             <span className='text-lg group-hover:text-blue-600 group-hover:underline'>
               {item.title}{" "}
             </span>
-            {item.escalated && (
-              <span
-              className='px-1 py-1 bg-purple-300 rounded-full font-medium text-sm text-slate-600 inline-flex gap-1 items-center no-underline w-fit'>
-                {incidentOverallStatus(item)}
-              </span>
-            )}
+            <span
+            className='px-1 py-1 bg-purple-300 rounded-full font-medium text-sm text-slate-600 inline-flex gap-1 items-center no-underline w-fit'>
+              {incidentOverallStatus(item)}
+            </span>
           </h2>
           <div className='grid grid-cols-4 flex-grow items-end font-medium'>
             <p>

--- a/src/pages/incidents/incidentOverallStatus.ts
+++ b/src/pages/incidents/incidentOverallStatus.ts
@@ -1,0 +1,32 @@
+import { Group } from "../../api/groups/types";
+import { isNil } from "lodash";
+
+export default function incidentOverallStatus({
+  verification_status,
+  confirmation_status,
+  publication_status,
+}: Group) {
+  if (publication_status.includes("Shared with Networks")) {
+    return "Shared with Networks";
+  } else if (publication_status.includes("Published")) {
+    return "Published";
+  }
+
+  if (!isNil(confirmation_status)) {
+    if (confirmation_status) {
+      return "Confirmed";
+    } else {
+      return "Unable to Confirm";
+    }
+  }
+
+  if (!isNil(verification_status)) {
+    if (verification_status) {
+      return "Confirming";
+    } else {
+      return "Unable to Verify";
+    }
+  }
+
+  return "Verifying Measurement";
+}


### PR DESCRIPTION
**added overall incident status**

closes #18

# feature

- added overall incident status, a status aggregating `verification_status`, `confirmation_status`, and `publication_status` according to the graph shown in #18
  - made `verification_status` and `confirmation_status` non-required parameters to accommodate for `null` value
  - added `src/pages/incidents/incidentOverallStatus.ts` to calculate overall status from the Group object