### PR TITLE
[frontend] Feat: incident datetime

### DIFF
--- a/src/components/FormikDate.tsx
+++ b/src/components/FormikDate.tsx
@@ -1,6 +1,6 @@
 import { faExclamationTriangle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { Field, useField } from "formik";
+import { useField } from "formik";
 
 interface IProps {
   name: string;
@@ -16,9 +16,9 @@ const FormikDate = ({ name, label }: IProps) => {
 
       <input
         name={name}
-        type='date'
-        value={value || ""}
-        onChange={(e) => setValue(e.target.value)}
+        type='datetime-local'
+        value={value.toString().slice(0, 16) || ""}
+        onChange={(e) => setValue(e.target.value + ":00.000Z")}
         className='px-3 py-2 focus-theme rounded border border-slate-300 bg-slate-50 text-black'
       />
       {meta.touched && meta.error ? (

--- a/src/components/FormikDateTime.tsx
+++ b/src/components/FormikDateTime.tsx
@@ -6,7 +6,7 @@ interface IProps {
   name: string;
   label?: string;
 }
-const FormikDate = ({ name, label }: IProps) => {
+const FormikDateTime = ({ name, label }: IProps) => {
   const [field, meta, helpers] = useField(name);
   const { value } = meta;
   const { setValue } = helpers;
@@ -30,4 +30,4 @@ const FormikDate = ({ name, label }: IProps) => {
     </label>
   );
 };
-export default FormikDate;
+export default FormikDateTime;

--- a/src/pages/incidents/CreateEditIncidentForm.tsx
+++ b/src/pages/incidents/CreateEditIncidentForm.tsx
@@ -65,8 +65,8 @@ const CreateEditIncidentForm = ({
           publication_status: group?.publication_status || ["Not Published"],
           assignedTo: group?.assignedTo?.map((i) => i._id) || [],
           notes: group?.notes || "",
-          incidentStartedAt: group?.incidentStartedAt?.toString().slice(0, 10) || "",
-          incidentEndedAt: group?.incidentEndedAt?.toString().slice(0, 10) || "",
+          incidentStartedAt: group?.incidentStartedAt || "",
+          incidentEndedAt: group?.incidentEndedAt || "",
         }}
         schema={incidentSchema}
         onSubmit={(values: GroupEditableData) => {

--- a/src/pages/incidents/CreateEditIncidentForm.tsx
+++ b/src/pages/incidents/CreateEditIncidentForm.tsx
@@ -5,7 +5,7 @@ import * as Yup from "yup";
 import { PUBLISHED_OPTIONS, Group, GroupEditableData } from "../../api/groups/types";
 import { getUsers } from "../../api/users";
 
-import FormikDate from "../../components/FormikDate";
+import FormikDateTime from "../../components/FormikDateTime";
 import FormikDropdown from "../../components/FormikDropdown";
 import FormikInput from "../../components/FormikInput";
 import FormikMultiCombobox from "../../components/FormikMultiCombobox";
@@ -108,13 +108,13 @@ const CreateEditIncidentForm = ({
 
         <div className=' border-b'></div>
 
-        <FormikDate
+        <FormikDateTime
           name='incidentStartedAt'
-          label='Incident Start Date'
+          label='Incident Start Time (UTC)'
         />
-        <FormikDate
+        <FormikDateTime
           name='incidentEndedAt'
-          label='Incident End Date'
+          label='Incident End Time (UTC)'
         />
         <FormikInput name='locationName' label='Location' />
 

--- a/src/pages/incidents/Incident/IncidentInfo.tsx
+++ b/src/pages/incidents/Incident/IncidentInfo.tsx
@@ -23,13 +23,15 @@ interface IProps {
   onEdit: () => void;
 }
 const IncidentInfo = ({ group, isLoading, onEdit }: IProps) => {
-  function isoToYMD (iso : string | Date) {
+  function formatIsoTime (iso : string | Date) {
     if (!iso) return "Unknown Date";
     const date = (iso instanceof Date) ? iso : new Date(iso);
-    const day = String(date.getUTCDate()).padStart(2, '0');
-    const month = String(date.getUTCMonth() + 1).padStart(2, '0');
     const year = date.getUTCFullYear();
-    return `${year}-${month}-${day}`;
+    const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+    const day = String(date.getUTCDate()).padStart(2, "0");
+    const hour = String(date.getUTCHours()).padStart(2, "0");
+    const minute = String(date.getUTCMinutes()).padStart(2, "0");
+    return `${year}-${month}-${day} ${hour}:${minute}`;
   }
   return (
     <header className='text-slate-600 border-b border-slate-300 py-2'>
@@ -135,14 +137,14 @@ const IncidentInfo = ({ group, isLoading, onEdit }: IProps) => {
         </PlaceholderDiv>
       </div>
       <div className='flex gap-2 items-center pt-2'>
-        <span className='whitespace-nowrap'>Incident Date:</span>
+        <span className='whitespace-nowrap'>Incident Time (UTC):</span>
         <PlaceholderDiv
           loading={isLoading}
           className='flex flex-wrap gap-x-2 gap-y-1 items-center '
         >
           {(group?.incidentStartedAt || group?.incidentEndedAt) ? (
             <p className='whitespace-pre-line max-w-prose text-black'>
-              {isoToYMD(group?.incidentStartedAt)} {<FontAwesomeIcon icon={faArrowRight} size="sm" />} {isoToYMD(group?.incidentEndedAt)}
+              {formatIsoTime(group?.incidentStartedAt)} {<FontAwesomeIcon icon={faArrowRight} size="sm" />} {formatIsoTime(group?.incidentEndedAt)}
             </p>
           ) : (
             <p className='italic text-slate-600'>No Date Set</p>

--- a/src/pages/incidents/IncidentListItem.tsx
+++ b/src/pages/incidents/IncidentListItem.tsx
@@ -109,9 +109,9 @@ const IncidentListItem = ({ item }: IProps) => {
             </div>
             <div className='text-xs'>
               {(item.incidentStartedAt || item.incidentEndedAt) && <p>
-                  <span>{item.incidentStartedAt?.toString().slice(0, 10) || "Unknown Date"}</span>
+                  <span>{item.incidentStartedAt?.toString().slice(0, 16).replace("T", " ") || "Unknown Date"}</span>
                   <span>{" "}<FontAwesomeIcon icon={faArrowRight} size="xs" />{" "}</span>
-                  <span>{item.incidentEndedAt?.toString().slice(0, 10) || "Unknown Date"}</span>
+                  <span>{item.incidentEndedAt?.toString().slice(0, 16).replace("T", " ") || "Unknown Date"}</span>
               </p>}
             </div>
           </div>


### PR DESCRIPTION
**added start and end time to incident (only had date)**

closes #30 

<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/58014856-1c9e-4a9c-9bb1-66df42675f6d" />

# feature

- added time to incident start and end date (users expected to enter in UTC, also noted in incident page)
  - fixes in `IncidentListItem`, `IncidentInfo`, and `CreateEditIncidentForm`

# change

- renamed `src/components/FormikDate.tsx` to `src/components/FormikDateTime.tsx`