### PR TITLE
frontend/fix: fixed showing incorrect number of alerts and posts

### DIFF
--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -68,7 +68,7 @@ const PrivateRoutes = ({ sessionData }: IPrivateRouteProps) => {
       <Route
         path='/alerts'
         element={
-          <Reports><AllReportsList alerts={true} /></Reports>
+          <Reports><AllReportsList alerts={true} key='alerts' /></Reports>
         }
       >
         <Route path=':id' element={<Report />}></Route>
@@ -77,7 +77,7 @@ const PrivateRoutes = ({ sessionData }: IPrivateRouteProps) => {
       <Route
         path='/mediaposts'
         element={
-          <Reports><AllReportsList alerts={false} /></Reports>
+          <Reports><AllReportsList alerts={false} key='mediaposts' /></Reports>
         }
       >
         <Route path=':id' element={<Report />}></Route>

--- a/src/api/reports/index.ts
+++ b/src/api/reports/index.ts
@@ -6,10 +6,10 @@ import { isString } from "lodash";
 
 export const getReports = async (
   searchState: ReportQueryState,
+  alerts?: boolean,
   tagIds: hasId[] | string[] = [],
-  isRelevantReports = false
 ) => {
-  const urlparams = urlFromReportsQuery(searchState, tagIds);
+  const urlparams = urlFromReportsQuery(searchState, alerts, tagIds);
 
   if (urlparams != "") {
     const { data } = await axios.get<Reports | undefined>(
@@ -143,6 +143,7 @@ export const removeReportsFromGroup = async (
  */
 export function urlFromReportsQuery(
   queryState: ReportQueryState,
+  alerts?: boolean,
   tagIds: hasId[] | string[] = []
 ) {
   const url = new URLSearchParams();
@@ -158,6 +159,7 @@ export function urlFromReportsQuery(
   if (!("irrelevant" in queryState)) {
     url.set("irrelevant", "all");
   }
+  if (typeof alerts !== "undefined") url.set("alerts", alerts.toString());
   if (tagIds && tagIds.length > 0) {
     if (isString(tagIds[0])) url.set("tags", tagIds.toString());
     else {

--- a/src/api/reports/types.ts
+++ b/src/api/reports/types.ts
@@ -59,6 +59,7 @@ export interface ReportQueryState {
   page?: number;
   batch?: boolean;
   irrelevant?: string;
+  alerts?: boolean;
 }
 
 // metadata typed

--- a/src/pages/Reports/AllReportsList.tsx
+++ b/src/pages/Reports/AllReportsList.tsx
@@ -27,23 +27,13 @@ const AllReportsList = ({ alerts }: IProps) => {
     useQueryParams<ReportQueryState>();
 
   const {
-    data: rawReports,
+    data: reports,
     refetch,
     isLoading,
     isFetching,
-  } = useQuery(["reports"], () => getReports(getAllParams(searchParams)), {
+  } = useQuery(["reports"], () => getReports(getAllParams(searchParams), alerts), {
     refetchInterval: 120000,
   });
-  const reports = rawReports && {...rawReports, results: (rawReports.results.filter(
-    obj => (
-      obj.metadata
-      && (
-        alerts
-        ? !obj.metadata.hasOwnProperty("junkipediaId")
-        : obj.metadata.hasOwnProperty("junkipediaId")
-      )
-    )
-  ))};
   useEffect(() => {
     // refetch on filter change
     multiSelect.set([]);


### PR DESCRIPTION
**fixed showing incorrect number of alerts and posts**

# changes

- utilizes new backend feature in `/api/reports` which added the `alerts` parameter to respond with outage alerts or social media posts (or both if left blank)
  - removed manual reports filter to AllReportsList
- added keys to AllReportsList component instances in AppRouter to force remount
- added optional `alerts` parameter to getReports and urlFromReportsQuery to correctly fetch alerts or posts
  - instead of using `hooks/useQueryParams.setParams`, which appends the parameter to url