### PR TITLE
frontend/fix: small fixes

### DIFF
--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -43,8 +43,8 @@ export type EscalatedOptions = (typeof ESCALATED_OPTIONS)[number];
 export const CLOSED_OPTIONS = ["true", "false"] as const;
 export type ClosedOptions = (typeof CLOSED_OPTIONS)[number];
 
-export const IRRELEVANCE_OPTIONS = ["true", "maybe", "false"] as const;
-export type IrrelevanceOptions = (typeof IRRELEVANCE_OPTIONS)[number];
+export const TERNARY_OPTIONS = ["true", "maybe", "false"] as const;
+export type TernaryOptions = (typeof TERNARY_OPTIONS)[number];
 
 export const CREDENTIAL_OPTIONS = ["junkipedia", "ioda", "cloudflare"] as const;
 export type CredentialOption = (typeof CREDENTIAL_OPTIONS)[number];

--- a/src/api/groups/types.ts
+++ b/src/api/groups/types.ts
@@ -1,4 +1,4 @@
-import { hasId, GroupSortBy } from "../common";
+import { hasId, GroupSortBy, TernaryOptions } from "../common";
 import { User } from "../users/types";
 
 export const PUBLISHED_OPTIONS = [
@@ -20,8 +20,8 @@ export interface Group extends hasId {
   id?: number;
   smtcTags: string[];
   status: string;
-  verification_status: boolean;
-  confirmation_status: boolean;
+  verification_status: TernaryOptions;
+  confirmation_status: TernaryOptions;
   publication_status: PublishedOptions[];
   escalated: boolean;
   closed: boolean;

--- a/src/api/groups/types.ts
+++ b/src/api/groups/types.ts
@@ -20,8 +20,8 @@ export interface Group extends hasId {
   id?: number;
   smtcTags: string[];
   status: string;
-  verification_status: TernaryOptions;
-  confirmation_status: TernaryOptions;
+  verification_status: TernaryOptions | boolean | null;
+  confirmation_status: TernaryOptions | boolean | null;
   publication_status: PublishedOptions[];
   escalated: boolean;
   closed: boolean;

--- a/src/api/reports/index.ts
+++ b/src/api/reports/index.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import type { Report, ReportQueryState, Reports } from "./types";
 
-import type { hasId, IrrelevanceOptions, VeracityOptions } from "../common";
+import type { hasId, TernaryOptions, VeracityOptions } from "../common";
 import { isString } from "lodash";
 
 export const getReports = async (
@@ -70,7 +70,7 @@ export const setSelectedVeracity = async (
 
 export const setSelectedIrrelevance = async (
   reportIds: string[],
-  irrelevance: IrrelevanceOptions | string
+  irrelevance: TernaryOptions | string
 ) => {
   const { data } = await axios.patch("/api/report/_irrelevance", {
     ids: reportIds,

--- a/src/api/reports/types.ts
+++ b/src/api/reports/types.ts
@@ -2,7 +2,7 @@ import type {
   hasId,
   VeracityOptions,
   MediaOptions,
-  IrrelevanceOptions,
+  TernaryOptions,
 } from "../common";
 
 export interface Report extends hasId {
@@ -25,7 +25,7 @@ export interface Report extends hasId {
   commentTo: string;
   notes: string;
   originalPost: string;
-  irrelevant?: IrrelevanceOptions;
+  irrelevant?: TernaryOptions;
   __v: number;
   aitags: GeneratedTags;
   aitagnames: string[];

--- a/src/components/FormikDropdown.tsx
+++ b/src/components/FormikDropdown.tsx
@@ -12,7 +12,7 @@ import { Listbox } from "@headlessui/react";
 interface IProps {
   label: string;
   name: string;
-  list: { _id: string | undefined; label: string }[];
+  list: { _id: string; label: string }[];
   disabled?: boolean;
   placeholder?: string;
   icon?: IconProp;

--- a/src/components/FormikDropdown.tsx
+++ b/src/components/FormikDropdown.tsx
@@ -12,7 +12,7 @@ import { Listbox } from "@headlessui/react";
 interface IProps {
   label: string;
   name: string;
-  list: { _id: string; label: string }[];
+  list: { _id: string | undefined; label: string }[];
   disabled?: boolean;
   placeholder?: string;
   icon?: IconProp;

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useQueryParams } from "../hooks/useQueryParams";
@@ -43,6 +43,7 @@ const Login = ({ }: IProps) => {
       password: values.loginPassword,
     };
   };
+  useEffect(() => {document.title = "Aggie"}, []);
   return (
     <main
       className='grid place-items-center h-[100svh]'

--- a/src/pages/Reports/AllReportsList.tsx
+++ b/src/pages/Reports/AllReportsList.tsx
@@ -35,6 +35,7 @@ const AllReportsList = ({ alerts }: IProps) => {
     refetchInterval: 120000,
   });
   useEffect(() => {
+    document.title = alerts ? "Alerts - Aggie" : "Social Media Posts - Aggie";
     // refetch on filter change
     multiSelect.set([]);
     // apparanty not the way its supposed to be done but i cant do it another way

--- a/src/pages/Reports/components/AddReportsToIncident.tsx
+++ b/src/pages/Reports/components/AddReportsToIncident.tsx
@@ -42,7 +42,6 @@ const AddReportsToIncidents = ({
   onSuccess,
   addRemove,
 }: IAddReportsToIncidents) => {
-  const [selectedIncident, setSelectedIncident] = useState<Group>();
   const queryClient = useQueryClient();
   const queryData = useUpdateQueryData();
   const navigate = useNavigate();
@@ -109,34 +108,12 @@ const AddReportsToIncidents = ({
       <div className='fixed inset-0 bg-black/30' aria-hidden='true' />
       <div className='fixed inset-0 flex w-screen items-center justify-center p-4'>
         <Dialog.Panel className='bg-gray-50 rounded-xl border border-slate-200 shadow-xl min-w-24 h-[90vh] min-h-12 p-3 grid grid-cols-4 gap-y-1 gap-x-4 w-full	grid-rows-[auto_1fr]'>
-          <div className='col-span-full flex justify-between '>
-            <div className='flex-1'>
-              <AggieButton variant='secondary' onClick={onClose}>
-                Cancel
-              </AggieButton>
-            </div>
+          <div className='col-span-full flex items-center justify-center'>
+            <AggieButton variant='secondary' onClick={onClose} className='absolute left-7'>
+              Cancel
+            </AggieButton>
 
             <p className='font-medium text-lg'>Select an Incident Below:</p>
-            <div className='flex-1 flex justify-end gap-1'>
-              {/*<AggieButton
-                variant='secondary'
-                icon={faFileCirclePlus}
-                onClick={onNewIncidentFromReports}
-                className='hover:bg-slate-50 hover:underline text-blue-600 text-sm'
-              >
-                Create New Incident
-              </AggieButton>
-              <AggieButton
-                variant='primary'
-                onClick={onAddIncident}
-                loading={doAddReportToIncident.isLoading}
-                disabled={doAddReportToIncident.isLoading || !selectedIncident}
-              >
-                Add {selection ? `${selection.length}` : ""} report(s) to
-                incident
-              </AggieButton>
-              */}
-            </div>
           </div>
 
           <div className='overflow-y-auto flex flex-col gap-1 h-full col-span-1 border-2 border-dashed border-slate-300 bg-slate-50 rounded-lg p-3'>
@@ -179,19 +156,17 @@ const AddReportsToIncidents = ({
               totalCount={incidents && incidents.total}
             />
             <div className='overflow-y-auto bg-white border border-slate-300 rounded-lg'>
-            <AggieButton
-              className='hover:bg-green-100 border-b border-slate-200 font-medium gap-2 h-16 items-center text-left w-full'
-              icon={faFileCirclePlus}
-              padding='px-2 py-2'
-              onClick={onNewIncidentFromReports}
-            >
-              Create new incident
-            </AggieButton>
+              <AggieButton
+                className='hover:bg-green-100 active:bg-green-200 border-b border-slate-200 font-medium gap-2 h-16 items-center text-left w-full'
+                icon={faFileCirclePlus}
+                padding='px-2 py-2'
+                onClick={onNewIncidentFromReports}
+              >
+                Create new incident
+              </AggieButton>
               <NestedIncidentsList
                 incidents={incidents}
-                selectedIncident={selectedIncident}
                 onIncidentClicked={(item) => {
-                  setSelectedIncident(item);
                   onAddIncident(item);
                 }}
               />

--- a/src/pages/Reports/components/AddReportsToIncident.tsx
+++ b/src/pages/Reports/components/AddReportsToIncident.tsx
@@ -180,7 +180,7 @@ const AddReportsToIncidents = ({
             />
             <div className='overflow-y-auto bg-white border border-slate-300 rounded-lg'>
             <AggieButton
-              className='hover:bg-blue-100 border-b border-slate-200 font-medium gap-2 h-16 items-center text-left w-full'
+              className='hover:bg-green-100 border-b border-slate-200 font-medium gap-2 h-16 items-center text-left w-full'
               icon={faFileCirclePlus}
               padding='px-2 py-2'
               onClick={onNewIncidentFromReports}

--- a/src/pages/Reports/components/AddReportsToIncident.tsx
+++ b/src/pages/Reports/components/AddReportsToIncident.tsx
@@ -84,11 +84,11 @@ const AddReportsToIncidents = ({
     },
   });
 
-  function onAddIncident() {
-    if (!selection || selection.length === 0 || !selectedIncident) return;
+  function onAddIncident(item: Group) {
+    if (!selection || selection.length === 0 || !item) return;
     doAddReportToIncident.mutate({
       reportIds: selection.map((i) => i._id),
-      groupId: selectedIncident,
+      groupId: item,
     });
   }
 
@@ -118,7 +118,7 @@ const AddReportsToIncidents = ({
 
             <p className='font-medium text-lg'>Select an Incident Below:</p>
             <div className='flex-1 flex justify-end gap-1'>
-              <AggieButton
+              {/*<AggieButton
                 variant='secondary'
                 icon={faFileCirclePlus}
                 onClick={onNewIncidentFromReports}
@@ -135,6 +135,7 @@ const AddReportsToIncidents = ({
                 Add {selection ? `${selection.length}` : ""} report(s) to
                 incident
               </AggieButton>
+              */}
             </div>
           </div>
 
@@ -178,10 +179,21 @@ const AddReportsToIncidents = ({
               totalCount={incidents && incidents.total}
             />
             <div className='overflow-y-auto bg-white border border-slate-300 rounded-lg'>
+            <AggieButton
+              className='hover:bg-blue-100 border-b border-slate-200 font-medium gap-2 h-16 items-center text-left w-full'
+              icon={faFileCirclePlus}
+              padding='px-2 py-2'
+              onClick={onNewIncidentFromReports}
+            >
+              Create new incident
+            </AggieButton>
               <NestedIncidentsList
                 incidents={incidents}
                 selectedIncident={selectedIncident}
-                onIncidentClicked={(item) => setSelectedIncident(item)}
+                onIncidentClicked={(item) => {
+                  setSelectedIncident(item);
+                  onAddIncident(item);
+                }}
               />
             </div>
           </div>

--- a/src/pages/Reports/components/NestedIncidentsList.tsx
+++ b/src/pages/Reports/components/NestedIncidentsList.tsx
@@ -17,13 +17,11 @@ import UserToken from "../../../components/UserToken";
 
 interface IProps {
   incidents?: Groups;
-  selectedIncident?: Group;
   onIncidentClicked: (item: Group) => void;
 }
 
 const NestedIncidentsList = ({
   incidents,
-  selectedIncident,
   onIncidentClicked,
 }: IProps) => {
   const navigate = useNavigate();
@@ -40,11 +38,7 @@ const NestedIncidentsList = ({
         incidents.results.map((item) => (
           <button
             key={item._id}
-            className={`w-full text-left ${
-              selectedIncident?._id === item._id
-                ? "bg-blue-200"
-                : "hover:bg-blue-100"
-            }`}
+            className='w-full text-left active:bg-blue-200 hover:bg-blue-100'
             onClick={() => onIncidentClicked(item)}
           >
             <article className='grid grid-cols-4 lg:grid-cols-6 px-2 py-2 text-sm text-slate-500  group-hover:bg-slate-50 border-b border-slate-200'>

--- a/src/pages/Reports/useReportMutations.ts
+++ b/src/pages/Reports/useReportMutations.ts
@@ -1,7 +1,7 @@
 import { useMutation } from "@tanstack/react-query";
 import { useUpdateQueryData } from "../../hooks/useUpdateQueryData";
 
-import { IrrelevanceOptions } from "../../api/common";
+import { TernaryOptions } from "../../api/common";
 import {
   setSelectedRead,
   setSelectedIrrelevance,
@@ -82,7 +82,7 @@ export const useReportMutations = (
   const setIrrelevance = useMutation({
     mutationFn: (params: {
       reportIds: string[];
-      irrelevant: IrrelevanceOptions;
+      irrelevant: TernaryOptions;
       currentPageId?: string;
     }) => setSelectedIrrelevance(params.reportIds, params.irrelevant),
     onSuccess: (_, params) => {

--- a/src/pages/Settings/index.tsx
+++ b/src/pages/Settings/index.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import {
   faCog,
   faKey,
@@ -35,6 +36,8 @@ export function menuLinks(role: string | undefined) {
 const Settings = () => {
   const location = useLocation();
   const { data: session } = useQuery(["session"], getSession);
+
+  useEffect(() => {document.title = "Settings - Aggie"}, []);
 
   return (
     <section className='max-w-screen-xl mx-auto w-full grid grid-cols-5 gap-4'>

--- a/src/pages/Style.tsx
+++ b/src/pages/Style.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import AggieButton from "../components/AggieButton";
 import AggieCheck from "../components/AggieCheck";
@@ -11,6 +11,7 @@ function voidFuncParam(e: any) {return;}
 
 export default function Style() {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
+  useEffect(() => {document.title = "Style - Aggie"}, []);
   return (<>
     <div className='flex flex-wrap'>
       <AggieButton>default AggieButton</AggieButton>

--- a/src/pages/incidents/CreateEditIncidentForm.tsx
+++ b/src/pages/incidents/CreateEditIncidentForm.tsx
@@ -27,8 +27,8 @@ const incidentSchema = Yup.object().shape({
   title: Yup.string().required("Group name required"),
   locationName: Yup.string(),
   closed: Yup.boolean(),
-  verification_status: Yup.boolean(),
-  confirmation_status: Yup.boolean(),
+  verification_status: Yup.string(),
+  confirmation_status: Yup.string(),
   publication_status: Yup.array(Yup.string())
     .required("publication status required").min(1).max(2)
     .test(
@@ -69,8 +69,8 @@ const CreateEditIncidentForm = ({
           title: group?.title || "",
           locationName: group?.locationName || "",
           closed: group?.closed || false,
-          verification_status: group?.verification_status,
-          confirmation_status: group?.confirmation_status,
+          verification_status: group?.verification_status || "maybe",
+          confirmation_status: group?.confirmation_status || "maybe",
           publication_status: group?.publication_status || ["Not Published"],
           assignedTo: group?.assignedTo?.map((i) => i._id) || [],
           notes: group?.notes || "",
@@ -110,14 +110,24 @@ const CreateEditIncidentForm = ({
         <FormikDropdown
           name='verification_status'
           label='Outage verified?'
-          list={[{_id: "true", label: "Verified"}, {_id: "false", label: "Unable to Verify"}]}
+          list={[
+            // https://formik.org/docs/guides/validation#frequently-asked-questions
+            // Formik uses undefined to represent empty states.
+            {_id: "maybe", label: "Verifying"},
+            {_id: "true", label: "Verified"},
+            {_id: "false", label: "Unable to Verify"},
+          ]}
           placeholder='Verifying'
           icon={faMagnifyingGlassChart}
         />
         <FormikDropdown
           name='confirmation_status'
           label='Reason confirmed?'
-          list={[{_id: "true", label: "Confirmed"}, {_id: "false", label: "Unable to Confirm"}]}
+          list={[
+            {_id: "maybe", label: "Confirming"},
+            {_id: "true", label: "Confirmed"},
+            {_id: "false", label: "Unable to Confirm"},
+          ]}
           placeholder='Confirming'
           icon={faCommentNodes}
         />

--- a/src/pages/incidents/Incident/index.tsx
+++ b/src/pages/incidents/Incident/index.tsx
@@ -126,9 +126,9 @@ const Incident = () => {
   });
 
   useEffect(() => {
-    document.title = `${group?.title ? group.title : "Unnamed Incident"} - Aggie`;
     // refetch on filter change
     groupRefetch();
+    document.title = `${group?.title ? group.title : "Incident"} - Aggie`;
     multiSelect.set([]);
     window.scrollTo({
       top: 0,

--- a/src/pages/incidents/Incident/index.tsx
+++ b/src/pages/incidents/Incident/index.tsx
@@ -126,6 +126,7 @@ const Incident = () => {
   });
 
   useEffect(() => {
+    document.title = `${group?.title ? group.title : "Unnamed Incident"} - Aggie`;
     // refetch on filter change
     groupRefetch();
     multiSelect.set([]);

--- a/src/pages/incidents/IncidentStatuses.tsx
+++ b/src/pages/incidents/IncidentStatuses.tsx
@@ -30,36 +30,36 @@ export function IncidentOverallStatus({
     );
   }
 
-  if (!isNil(confirmation_status)) {
-    if (confirmation_status) {
+  switch (confirmation_status) {
+    case "true":
       return (
         <p className={`bg-green-300 ${className}`} {...props}>
           Confirmed
         </p>
       );
-    } else {
+    case "false":
       return (
         <p className={`bg-orange-300 ${className}`} {...props}>
           Unable to Confirm
         </p>
       );
-    }
+    default:
   }
 
-  if (!isNil(verification_status)) {
-    if (verification_status) {
+  switch (verification_status) {
+    case "true":
       return (
         <p className={`bg-yellow-300 ${className}`} {...props}>
           Confirming
         </p>
       );
-    } else {
+    case "false":
       return (
         <p className={`bg-red-300 ${className}`} {...props}>
           Unable to Verify
         </p>
       );
-    }
+    default:
   }
 
   return (
@@ -79,30 +79,34 @@ export function IncidentStatuses({
     confirmation_status,
     publication_status,
   } = group;
-    const verified = (
-      isNil(verification_status)
-      ? <span className={`bg-amber-300 ${className}`} {...props}>Verifying</span>
-      : verification_status
-        ? <span className={`bg-lime-300 ${className}`} {...props}>Verified</span>
-        : <span className={`bg-red-300 ${className}`} {...props}>Unable to Verify</span>
-    );
-    const confirmed = (
-      isNil(confirmation_status)
-      ? <span className={`bg-yellow-300 ${className}`} {...props}>Confirming</span>
-      : confirmation_status
-        ? <span className={`bg-green-300 ${className}`} {...props}>Confirmed</span>
-        : <span className={`bg-orange-300 ${className}`} {...props}>Unable to Confirm</span>
-    );
-    const published = (
-      publication_status.includes("Published")
-      ? <span className={`bg-emerald-300 ${className}`} {...props}>Published</span>
-      : <span className={`bg-fuchsia-300 ${className}`} {...props}>Not Published</span>
-    );
-    const shared = (
-      publication_status.includes("Shared with Networks")
-      && <span className={`bg-teal-300 ${className}`} {...props}>Shared with Networks</span>
-    );
-    return (<div className='flex gap-2'>
-      {verified}{confirmed}{published}{shared}
-    </div>);
+  const verified = (
+    verification_status === "maybe"
+    ? <span className={`bg-amber-300 ${className}`} {...props}>Verifying</span>
+    : verification_status === "true"
+      ? <span className={`bg-lime-300 ${className}`} {...props}>Verified</span>
+      : verification_status === "false"
+        ? <span className={`bg-red-300 ${className}`} {...props}>Unable to Verify</span>
+        : null
+  );
+  const confirmed = (
+    confirmation_status === "maybe"
+    ? <span className={`bg-yellow-300 ${className}`} {...props}>Confirming</span>
+    : confirmation_status === "true"
+      ? <span className={`bg-green-300 ${className}`} {...props}>Confirmed</span>
+      : confirmation_status === "false"
+        ? <span className={`bg-orange-300 ${className}`} {...props}>Unable to Confirm</span>
+        : null
+  );
+  const published = (
+    publication_status.includes("Published")
+    ? <span className={`bg-emerald-300 ${className}`} {...props}>Published</span>
+    : <span className={`bg-fuchsia-300 ${className}`} {...props}>Not Published</span>
+  );
+  const shared = (
+    publication_status.includes("Shared with Networks")
+    && <span className={`bg-teal-300 ${className}`} {...props}>Shared with Networks</span>
+  );
+  return (<div className='flex gap-2'>
+    {verified}{confirmed}{published}{shared}
+  </div>);
 }

--- a/src/pages/incidents/IncidentStatuses.tsx
+++ b/src/pages/incidents/IncidentStatuses.tsx
@@ -31,12 +31,14 @@ export function IncidentOverallStatus({
   }
 
   switch (confirmation_status) {
+    case true:
     case "true":
       return (
         <p className={`bg-green-300 ${className}`} {...props}>
           Confirmed
         </p>
       );
+    case false:
     case "false":
       return (
         <p className={`bg-orange-300 ${className}`} {...props}>
@@ -47,12 +49,14 @@ export function IncidentOverallStatus({
   }
 
   switch (verification_status) {
+    case true:
     case "true":
       return (
         <p className={`bg-yellow-300 ${className}`} {...props}>
           Confirming
         </p>
       );
+    case false:
     case "false":
       return (
         <p className={`bg-red-300 ${className}`} {...props}>
@@ -80,20 +84,20 @@ export function IncidentStatuses({
     publication_status,
   } = group;
   const verified = (
-    verification_status === "maybe"
+    verification_status === "maybe" || isNil(verification_status)
     ? <span className={`bg-amber-300 ${className}`} {...props}>Verifying</span>
-    : verification_status === "true"
+    : verification_status === "true" || verification_status === true
       ? <span className={`bg-lime-300 ${className}`} {...props}>Verified</span>
-      : verification_status === "false"
+      : verification_status === "false" || verification_status === false
         ? <span className={`bg-red-300 ${className}`} {...props}>Unable to Verify</span>
         : null
   );
   const confirmed = (
-    confirmation_status === "maybe"
+    confirmation_status === "maybe" || isNil(confirmation_status)
     ? <span className={`bg-yellow-300 ${className}`} {...props}>Confirming</span>
-    : confirmation_status === "true"
+    : confirmation_status === "true" || confirmation_status === true
       ? <span className={`bg-green-300 ${className}`} {...props}>Confirmed</span>
-      : confirmation_status === "false"
+      : confirmation_status === "false" || confirmation_status === false
         ? <span className={`bg-orange-300 ${className}`} {...props}>Unable to Confirm</span>
         : null
   );

--- a/src/pages/incidents/NewIncident/index.tsx
+++ b/src/pages/incidents/NewIncident/index.tsx
@@ -56,6 +56,7 @@ const NewIncident = () => {
   });
 
   useEffect(() => {
+    document.title = "New Incident - Aggie";
     const key = getParam("key") || "reports";
     const data = queryClient.getQueryData<Reports>([key]);
     if (!data) return;

--- a/src/pages/incidents/NewIncident/index.tsx
+++ b/src/pages/incidents/NewIncident/index.tsx
@@ -44,7 +44,7 @@ const NewIncident = () => {
         return;
       }
       if (!getParam("reports")) {
-        navigate(`/incidents/${data._id}`);
+        navigate(`/incidents/${data._id}`, { replace: true });
         return;
       }
 

--- a/src/pages/incidents/index.tsx
+++ b/src/pages/incidents/index.tsx
@@ -32,6 +32,7 @@ const Incidents = () => {
   );
 
   useEffect(() => {
+    document.title = "Incidents - Aggie";
     // refetch on filter change
     refetch();
     document.getElementById("main_view")?.scrollTo({


### PR DESCRIPTION
# changes

- adding reports to incident now only takes 1 click on the incident, removed selecting incident then clicking on "add" button, closes #28
  - moved new incident option to be listed along other incidents
- fixed "Go Back" button returning to new incident page after creating new incident
- added page titles that show up in browser tab list
- renamed `IrrelevanceOptions` to `TernaryOptions` so it can be reused for incident statuses
- updated verify and confirm incident statuses to new format
  - fields take strings enum `false`, `true`, and `maybe`, like the `irrelevance` field
  - statuses still check for `undefined` and booleans to maintain backward compatibility, since old incidents are still stored as booleans, but future updates to incidents should and must use strings as described above