### PR TITLE
 Feat: Password Changing (non-admin users) & Enhancement: Attachment Upload Size and Supported File Type 

### DIFF
--- a/backend/api.js
+++ b/backend/api.js
@@ -88,6 +88,11 @@ if (process.env.ENVIRONMENT === 'development') {
       credentials: true, // allow session cookie from browser to pass through
     })
   );
+  app.use(
+    '/incidents/uploads',
+    auth.authenticate(),
+    express.static(path.join(__dirname,'..', 'public', 'uploads'))
+  );
   app.use(function (req, res, next) {
     res.header('Access-Control-Allow-Credentials', true);
     res.header('Access-Control-Allow-Origin', req.headers.origin);

--- a/backend/api/middlewares/groupMiddlewares.js
+++ b/backend/api/middlewares/groupMiddlewares.js
@@ -1,7 +1,7 @@
 const multer = require('multer');
 const { MAX_ATTACHMENT_SIZE, MAX_ATTACHMENT_COUNT } = require('../../models/group');
 
-const allowedMimeTypes = ['image/jpeg', 'image/png', 'application/pdf'];
+const allowedMimeTypes = ['image/jpeg', 'image/png', 'application/pdf', 'text/csv', 'text/plain'];
 
 const upload = multer({
     storage: multer.memoryStorage(),

--- a/backend/api/routes/userRoutes.js
+++ b/backend/api/routes/userRoutes.js
@@ -20,5 +20,5 @@ router.put('/:_id', User.can('update users'), userController.user_update);
 router.delete('/:_id', User.can('admin users'), userController.user_delete);
 
 // Update User password
-router.put('/password_set/:_id', User.can('admin users'), userController.user_update_password);
+router.put('/password_set/:_id', User.can('update users'), userController.user_update_password);
 module.exports = router;

--- a/backend/config/models/groupConfigs.js
+++ b/backend/config/models/groupConfigs.js
@@ -1,5 +1,5 @@
 const MAX_ATTACHMENT_COUNT = 3;
-const MAX_ATTACHMENT_SIZE = 500 * 1024;
+const MAX_ATTACHMENT_SIZE = 5 * 1024 * 1024;
 
 module.exports = {
     MAX_ATTACHMENT_COUNT,

--- a/backend/fetching/channels/junkipedia.js
+++ b/backend/fetching/channels/junkipedia.js
@@ -7,7 +7,7 @@ const { decryptSecretsObject } = require('../utils/decryption');
 
 class JunkipediaChannel extends PageChannel {
   static BASE_URL = 'https://www.junkipedia.org';
-  static INTERVAL = 100000;
+  static INTERVAL = 3600000;
   static PER_PAGE = 100;
   #decryptedSecrets; // private property of decrypted secrets
 
@@ -40,13 +40,13 @@ class JunkipediaChannel extends PageChannel {
     let startDate;
 
     if (!this.lastTimestamp) {
-      startDate = Math.floor((Date.now() - 2 * 60 * 60 * 1000) / 1000); // 2-hrs before current time
+      startDate = Math.floor((Date.now() - 6 * 60 * 60 * 1000) / 1000); // 6-hrs before current time (junkipedia data update has delays despite of hour update)
     } else {
 
-      const fiveMinutesAgo = Math.floor((Date.now() - 5 * 60 * 1000) / 1000);
+      const sixHoursAgo = Math.floor((Date.now() - 6 * 60 * 60 * 1000) / 1000);
       const lastTimestampEpoch = Math.floor((this.lastTimestamp.getTime() + 1000) / 1000);
       
-      startDate = Math.min(fiveMinutesAgo, lastTimestampEpoch);
+      startDate = Math.min(sixHoursAgo, lastTimestampEpoch);
     }
 
     const apiKey = this.#decryptedSecrets.junkipediaAPIKey || null;
@@ -70,7 +70,7 @@ class JunkipediaChannel extends PageChannel {
         params: {
           ...this.queryParams,
           published_at_from: startDate,
-          published_at_to: Math.floor(Date.now() / 1000),
+          published_at_to: Math.floor((Date.now() - 5 * 60 * 60 * 1000) / 1000),
         },
       };
     }
@@ -93,12 +93,13 @@ class JunkipediaChannel extends PageChannel {
 
       console.log(`[Fetching-channel-Junkipedia] Success - Parsed and formatted data, total records: ${posts.length}.`);
       
-      const updatedTimestamp = config.params?.published_at_to
-        ? new Date(config.params.published_at_to * 1000)
-        : new Date(Date.now() - 100000);
+      if (posts.length > 0) {
+        const updatedTimestamp = config.params?.published_at_to
+          ? new Date(config.params.published_at_to * 1000)
+          : new Date(Date.now() - 100000);
 
-      this.lastTimestamp = updatedTimestamp;
-
+        this.lastTimestamp = updatedTimestamp;
+      }
       return posts;
       
     } catch (e) {


### PR DESCRIPTION
### What

This PR adds support for non-admin users to change password, while enhancing the attachment upload feature in incident page to increase supported size (at most 5MB/file ) with extra file type supports (csv / plain text)

### Changes:

Related to #57 - Password Changing:  api/userRoutes
Related to #61 - Attachment Upload: api/middlewares & config/model/groupConfigs