### PR TITLE
[frontend]Feat: Password Changing (non-admin users) & Enhancement: Attachment Upload Size and Supported File Type

### DIFF
--- a/src/api/groups/types.ts
+++ b/src/api/groups/types.ts
@@ -97,6 +97,8 @@ export const MIME_TYPES = [
   "application/pdf",
   "image/jpeg",
   "image/png",
+  "text/csv", 
+  "text/plain",
 ] as const;
 export type MimeTypes = (typeof MIME_TYPES)[number];
 

--- a/src/components/FileUploader.tsx
+++ b/src/components/FileUploader.tsx
@@ -7,7 +7,7 @@ import AggieButton from "./AggieButton";
 import { GroupCommentAttachment, MIME_TYPES } from "../api/groups/types";
 
 export const MAX_ATTACHMENT_COUNT = 3;
-export const MAX_ATTACHMENT_SIZE = 500 * 1024;
+export const MAX_ATTACHMENT_SIZE = 5 * 1024 * 1024;
 
 export class FilePickerManager {
   private files: (File | GroupCommentAttachment)[] = [];
@@ -105,7 +105,7 @@ export const FileUploadButton: React.FC<FileUploadButtonProps> = ({
       const selectedFiles = e.target.files ?? [];
       for (const element of selectedFiles) {
         if (element.size > MAX_ATTACHMENT_SIZE) {
-          setError(`file must be less than ${MAX_ATTACHMENT_SIZE / 1024} KiB`);
+          setError(`file must be less than ${MAX_ATTACHMENT_SIZE / (1024 * 1024)} MiB`);
           return;
         }
       }

--- a/src/components/FormikInput.tsx
+++ b/src/components/FormikInput.tsx
@@ -24,6 +24,7 @@ const FormikInput = ({ name, label, type, placeholder, icon }: IProps) => {
 
       <input
         name={name}
+        type={type || "text"}
         placeholder={placeholder ? placeholder : "Enter " + label}
         value={value || ""}
         onChange={(e) => setValue(e.target.value)}

--- a/src/components/SocialMediaPost/IodaEvent.tsx
+++ b/src/components/SocialMediaPost/IodaEvent.tsx
@@ -18,6 +18,7 @@ const IodaEvent = ({ report }: IProps) => {
 
   const image = rawData?.image?.
     replace('width="726"', 'width="100%"').
+    replace('width="733"', 'width="100%"').
     replace('height="514"', 'height="auto"') || "";
 
   return (

--- a/src/pages/Settings/user/SetPassword.tsx
+++ b/src/pages/Settings/user/SetPassword.tsx
@@ -7,6 +7,7 @@ import type { User } from "../../../api/users/types";
 import { Formik, Form } from "formik";
 import AggieButton from "../../../components/AggieButton";
 import FormikInput from "../../../components/FormikInput";
+import { Session } from "../../../api/session/types";
 
 const updatePasswordSchema = Yup.object().shape({
   password: Yup.string()
@@ -21,7 +22,7 @@ const updatePasswordSchema = Yup.object().shape({
 type IPasswordSchema = Yup.InferType<typeof updatePasswordSchema>;
 
 interface IProps {
-  user?: User;
+  user?: User | Session;
   onClose: () => void;
 }
 

--- a/src/pages/Settings/user/UserProfile.tsx
+++ b/src/pages/Settings/user/UserProfile.tsx
@@ -12,11 +12,12 @@ import AggieButton from "../../../components/AggieButton";
 import AggieDialog from "../../../components/AggieDialog";
 import CreateEditUserForm from "./CreateEditUserForm";
 import ConfirmationDialog from "../../../components/ConfirmationDialog";
-
+import SetPassword from "./SetPassword";
 import {
   faEllipsisH,
   faEdit,
   faTrashAlt,
+  faUserShield,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
@@ -33,6 +34,7 @@ const UserProfile = ({ session }: IProps) => {
   });
   const [openEdit, setOpenEdit] = useState(false);
   const [openDelete, setOpenDelete] = useState(false);
+  const [openEditPassword, setOpenEditPassword] = useState(false);
 
   const doDeleteUser = useMutation(deleteUser, {
     onSuccess: () => {
@@ -63,6 +65,13 @@ const UserProfile = ({ session }: IProps) => {
               >
                 <FontAwesomeIcon icon={faEdit} />
                 Edit
+              </AggieButton>
+              <AggieButton
+                className='px-3 py-2 hover:bg-slate-100 text-slate-600 w-full'
+                onClick={() => setOpenEditPassword(true)}
+              >
+                <FontAwesomeIcon icon={faUserShield} />
+                Change Password
               </AggieButton>
               <AggieButton
                 className='px-3 py-2 hover:bg-slate-100 text-red-600'
@@ -111,6 +120,19 @@ const UserProfile = ({ session }: IProps) => {
         }}
       >
         <CreateEditUserForm user={data} onClose={() => setOpenEdit(false)} />
+      </AggieDialog>
+      <AggieDialog
+        isOpen={!!openEditPassword}
+        onClose={() => setOpenEditPassword(false)}
+        className='px-3 py-4 w-full max-w-lg'
+        data={{
+          title: `Change password`,
+        }}
+      >
+        <SetPassword
+          user={session}
+          onClose={() => setOpenEditPassword(false)}
+        />
       </AggieDialog>
       <ConfirmationDialog
         isOpen={!!openDelete}


### PR DESCRIPTION
### What

This PR is a corresponding frontend PR to PR #68 . Adds support for non-admin users to change password, while enhancing the attachment upload feature in incident page to increase supported size (at most 5MB/file ) with extra file type supports (csv / plain text)

Also a minor fix on issue of IODA graph rendering exceeding container boundary

### Changes:

Related to #57  - Password Changing: pages/Settings/UserProfile & pages/Settings/SetPassword
Related to #61  - Attachment Upload: api/groups/types & components/FileUploader & components/FormikInput
bug fix - components/IodaEvent