### PR TITLE
[FIX-fetching-ioda] fix ioda channel showing incorrect graph issue.

### DIFF
--- a/backend/fetching/channels/ioda.js
+++ b/backend/fetching/channels/ioda.js
@@ -267,9 +267,15 @@ class IODAChannel extends PollChannel {
         Ended: ${eventEndedAt}
         Outage duration ${eventDuration}`;
 
-        // Render dashboard within a 24H time range (ending at current time)
-        const urlFromTime = this.fetchToTimestamp - 12 * 60 * 60;
-        const urlToTime = this.fetchToTimestamp;
+        // Render dashboard
+        const urlFromTime = eventStartedAtSeconds - 4 * 60 * 60;
+        const urlToTime = Math.min(
+            Math.max(
+                eventEndedAtSeconds + 4 * 60 * 60, 
+                urlFromTime + 24 * 60 * 60
+            ), 
+            this.fetchToTimestamp
+        );
         let entityCode = event.location;
 
         if (queryType === 'geoasn-region' || queryType === 'geoasn-country') {
@@ -317,7 +323,7 @@ class IODAChannel extends PollChannel {
         } else {
 
             try {
-                const cleanSVG = await extractCleanSVGFromPage(this.browser, linkedPage);
+                const cleanSVG = await extractCleanSVGFromPage(this.browser, linkedPage, queryType);
                 image = cleanSVG;
                 this.linkedPageCache[linkedPage] = cleanSVG;
             } catch (err) {

--- a/backend/fetching/utils/iodaUtils.js
+++ b/backend/fetching/utils/iodaUtils.js
@@ -6,7 +6,14 @@ const { JSDOM } = require('jsdom');
 const window = new JSDOM('').window;
 const DOMPurify = createDOMPurify(window);
 
-async function extractCleanSVGFromPage(browser, linkedPageUrl) {
+const chartIndexMap = {
+    'geoasn-country': '0',
+    'geoasn-region': '0',
+    'default': '1',
+  };
+
+
+async function extractCleanSVGFromPage(browser, linkedPageUrl, queryType) {
 
 
     const page = await browser.newPage();
@@ -15,9 +22,17 @@ async function extractCleanSVGFromPage(browser, linkedPageUrl) {
 
         await page.goto(linkedPageUrl, {waitUntil: 'networkidle'});
 
-        await page.waitForSelector('svg.highcharts-root', {timeout: 30000, state: 'attached',});
+        const chartIndex = chartIndexMap[queryType] || chartIndexMap['default'];
 
-        const rawSvg = await page.$eval('svg.highcharts-root', el => el.outerHTML);
+        await page.waitForSelector(`div[data-highcharts-chart="${chartIndex}"] svg.highcharts-root`, {
+            timeout: 30000, 
+            state: 'attached',
+        });
+
+        const rawSvg = await page.$eval(
+            `div[data-highcharts-chart="${chartIndex}"] svg.highcharts-root`, 
+            el => el.outerHTML
+        );
 
         const cleanSvg = DOMPurify.sanitize(rawSvg, {USE_PROFILES: {svg: true}});
 


### PR DESCRIPTION
### WHAT

a fix PR to fix issue below:

1. **svg graph**:  shows incorrectly, should render time trend of all signal instead of active probing/bgp signals. Close #70  
2. **linkedPage url**:  previous logic was problematic under data backfilling, url use fetch timestamp instead of event timestamp as query parameter. Close #72 

### CHANGES

1. iodaUtils: add chartIndex mapping relationship, map correct svg graph
2. channels/ioda.js: adjust the logic of query parameter urlFromTime & urlToTime in linkedPage url construction to be based on event time.  