### PR TITLE
[FIX-fetching-childprocess]Fix new source cannot automatically start fetch issue

### DIFF
--- a/backend/api/controllers/sourceController.js
+++ b/backend/api/controllers/sourceController.js
@@ -13,7 +13,7 @@ exports.source_create = (req, res) => {
       return res.status(err.status).send(err.message);
     }
     
-    res.send(200, source);
+    res.status(200).send(source);
   });
 }
 

--- a/backend/child-process.js
+++ b/backend/child-process.js
@@ -68,7 +68,7 @@ ChildProcess.prototype.registerOutgoingEmitter = function (options) {
   var emitter = require(options.emitter);
   if (options.subclass) emitter = emitter[options.subclass];
   // Listen to registered event
-  if (!_.includes(_.keys(emitter._events), options.registeredEvent)) {
+  if (!_.includes(_.keys(emitter._events), options.registeredEvent)||options.registeredEvent == 'source:save') {
     // Events emitted by the backend can have up to 1 argument (data)
     emitter.on(options.registeredEvent, function (data, other) {
       if (other) throw new Error('Events can only have one argument');


### PR DESCRIPTION
### WHAT

Fix issue in new source creation scenarios. New source can be created with "enabled" status but fetching did not actually start. Also fixed CTI-list integration issue. closes #65 


### CHANGE
remove restriction on inter-module event emission for specific events (e.g. source:save), these events are now emitted both intra-module and inter-module.