### PR TITLE
[frontend]FIX: dark mode not persist

### DIFF
--- a/src/Navbar.tsx
+++ b/src/Navbar.tsx
@@ -66,7 +66,17 @@ const AggieNavbar = ({ isAuthenticated, session }: IProps) => {
   };
 
   const [logoutModal, setLogoutModal] = useState(false);
-  const [isDark, setIsDark] = useState(false);
+  const [isDark, setIsDark] = useState<boolean>(()=>{
+    try {
+      const saved = localStorage.getItem("theme");
+      if (saved == "dark") return true;
+      if (saved == "light") return false;
+      return window.matchMedia && 
+            window.matchMedia("(prefers-color-scheme: dark)").matches;
+    } catch (error) {
+      return false;
+    }
+  })
   useEffect(() => {
     const root = document.documentElement;
     if (isDark) {
@@ -77,6 +87,18 @@ const AggieNavbar = ({ isAuthenticated, session }: IProps) => {
       localStorage.setItem("theme", "light");
     }
   }, [isDark]);
+  // ensure cross-tab dark mode consistency
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === "theme") {
+        setIsDark(e.newValue === "dark");
+      }
+    }
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, [])
+
+
 
 
   const doLogout = useMutation({


### PR DESCRIPTION
### WHAT

Fix the issue of dark mode not persist on refresh. Also add support for dark mode persistence across multiple tabs (i.e. when multiple tabs open, toggle dark mode in one tab change the mode in all rest tabs too).


### CHANGES

src/Navbar.tsx: update isDark state initialization, add cross-tab dark mode persistence effect