### PR TITLE
feat: User Role Access Control - add team lead

### DIFF
--- a/backend/api/controllers/userController.js
+++ b/backend/api/controllers/userController.js
@@ -8,8 +8,13 @@ const validator = require('validator');
 exports.user_users = (req, res) => {
   if (!req.user) return res.status(401).send("Unauthenticated.");
 
-  const isAdmin = req.user.role === "admin";
-  const filter = isAdmin ? {} : {_id: req.user._id};
+  const role = req.user.role;
+  let filter = { _id: req.user._id }
+  if (role === "admin") {
+    filter = {};
+  } else if (role === "team_lead") {
+    filter = { createdBy: req.user._id }; 
+  }
 
   User.find(filter, function (err, users) {
     if (err) {
@@ -23,10 +28,28 @@ exports.user_users = (req, res) => {
 
 // Get a User by id
 exports.user_detail = (req, res) => {
+  if (!req.user) return res.status(401).send('Unauthenticated.');
+
   User.findById(req.params._id, '-password', function (err, user) {
     if (err) { return res.status(err.status).send(err.message); }
     else if (!user) { return res.sendStatus(404); }
-    else { return res.status(200).send(user); }
+    else {
+      const role = req.user.role;
+      const isSelf = String(user._id) === String(req.user._id);
+      let allowed = false;
+
+      if (role === 'admin') {
+        allowed = true; 
+      } else if (role === 'team_lead') {
+        const createdByMe = String(user.createdBy) === String(req.user._id);
+        allowed = isSelf || createdByMe; 
+      } else {
+        allowed = isSelf; 
+      }
+
+      if (!allowed) return res.status(403).send('Unauthorized to view the user.');
+      return res.status(200).send(user);
+    }
   });
 };
 
@@ -40,16 +63,29 @@ exports.user_create = (req, res) => {
     '.'
   );
 
+  if (!req.user) return res.status(401).send('Unauthenticated.');
+
   if (!validator.isEmail(req.body.email)) {
     res.status(400).send('Please provide a valid email.');
   } else {
+
+    if (req.user.role === 'team_lead') {
+      const desiredRole = (req.body.role || '').toLowerCase();
+      if (!['viewer', 'monitor'].includes(desiredRole)) {
+        return res.status(403).send('Unauthorized.Team lead can only create viewer or monitor users.');
+      }
+    }
+
+    const payload = {
+      username: req.body.username,
+      displayName: req.body.displayName,
+      email: req.body.email,
+      role: req.body.role,
+      createdBy: req.user._id,    
+    };
+
     User.register(
-      {
-        username: req.body.username,
-        displayName: req.body.displayName,
-        email: req.body.email,
-        role: req.body.role,
-      },
+      payload,
       req.body.password,
       (err, user) => {
         if (err) {
@@ -57,7 +93,7 @@ exports.user_create = (req, res) => {
         } else {
           const authenticate = User.authenticate();
           authenticate(req.body.username, req.body.password, (err, result) => {
-            if (err) res.status(err.status).send(error.message);
+            if (err) res.status(err.status).send(err.message);
             else res.status(200).send(user);
           });
         }
@@ -137,9 +173,20 @@ exports.user_update_password = (req, res) => {
 
 // Delete a User
 exports.user_delete = (req, res) => {
+  if (!req.user) return res.status(401).send('Unauthenticated.');
+
   User.findById(req.params._id, (err, user) => {
     if (err) return res.status(err.status).send(err.message);
     if (!user) return res.sendStatus(404);
+
+    if (req.user.role === 'team_lead') {
+      const canDelete = String(user.createdBy) === String(req.user._id);
+      if (!canDelete) return res.status(403).send('Unauthorized to delete users you did not create.');
+      if (user.role === 'admin') {
+        return res.status(403).send('Unauthorized to delete admin users.');
+      }
+    }
+
     user.remove((err) => {
       err = Error.decode(err);
       if (err) res.status(err.status).send(err.message);

--- a/backend/api/routes/userRoutes.js
+++ b/backend/api/routes/userRoutes.js
@@ -8,7 +8,7 @@ const User = require('../../models/user');
 router.get('', User.can('view users'), userController.user_users);
 
 // Create a user
-router.post('', User.can('admin users'), userController.user_create);
+router.post('', User.can('change settings'), userController.user_create);
 
 // Get Individual User
 router.get('/:_id', User.can('view users'), userController.user_detail);
@@ -17,7 +17,7 @@ router.get('/:_id', User.can('view users'), userController.user_detail);
 router.put('/:_id', User.can('update users'), userController.user_update);
 
 // Delete User
-router.delete('/:_id', User.can('admin users'), userController.user_delete);
+router.delete('/:_id', User.can('delete users'), userController.user_delete);
 
 // Update User password
 router.put('/password_set/:_id', User.can('update users'), userController.user_update_password);

--- a/backend/models/user.js
+++ b/backend/models/user.js
@@ -15,7 +15,8 @@ var userSchema = new Schema({
   role: { type: String, default: 'viewer' },
   active: { type: Boolean, default: true },
   attempts: { type: Number, default: 0 },
-  last: { type: Date }
+  last: { type: Date },
+  createdBy: {type: Schema.Types.ObjectId, ref: 'User', index: true}
 });
 
 userSchema.plugin(passportLocalMongoose, {
@@ -26,12 +27,13 @@ var User = mongoose.model('User', userSchema);
 
 User.permissions = {
   'manage trends': ['admin'],
-  'view data': ['viewer', 'monitor', 'admin'],
-  'edit data': ['monitor', 'admin'],
-  'change settings': ['admin'],
-  'view users': ['viewer', 'monitor', 'admin'],
-  'view other users': ['manager', 'admin'],
+  'view data': ['viewer', 'monitor', 'admin', 'team_lead'],
+  'edit data': ['monitor', 'admin', 'team_lead'],
+  'change settings': ['admin', 'team_lead'],
+  'view users': ['viewer', 'monitor', 'admin', 'team_lead'],
+  'view other users': ['manager', 'admin','team_lead'],
   'update users': ['viewer', 'monitor', 'admin'],
+  'delete users': ['admin', 'team_lead'],
   'admin users': ['admin'],
   'change admin password': ['admin'],
   'edit tags': ['manager', 'admin']

--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -95,7 +95,7 @@ const PrivateRoutes = ({ sessionData }: IPrivateRouteProps) => {
           path='user/:id'
           element={<UserProfile session={sessionData} />}
         />
-        { sessionData?.role === "admin" &&
+        { (sessionData?.role === "admin" || sessionData?.role === "team_lead" ) &&
           <>
             <Route path='users' element={<UsersIndex session={sessionData} />} />
             <Route path='credentials' element={<CredentialsIndex />} />

--- a/src/api/session/types.ts
+++ b/src/api/session/types.ts
@@ -4,7 +4,7 @@ export interface Session extends hasId {
   email: string;
   hasDefaultPassword: boolean;
   provider: string;
-  role: "admin" | "monitor" | undefined;
+  role: "admin" | "monitor" |"viewer" |"team_lead" | undefined;
   username: string;
   __v: number;
 }

--- a/src/api/users/types.ts
+++ b/src/api/users/types.ts
@@ -1,6 +1,6 @@
 import { hasId } from "../common";
 
-export const USER_ROLES = ["viewer", "monitor", "admin"] as const;
+export const USER_ROLES = ["viewer", "monitor", "admin", "team_lead"] as const;
 export type UserRoles = (typeof USER_ROLES)[number];
 
 export interface User extends hasId {
@@ -11,6 +11,7 @@ export interface User extends hasId {
   username: string;
   displayName?: string;
   __v: number;
+  createdBy?: string;
 }
 
 export interface UserEditableData {

--- a/src/components/FormikInput.tsx
+++ b/src/components/FormikInput.tsx
@@ -13,8 +13,9 @@ interface IProps {
   type?: string;
   placeholder?: string;
   icon?: IconProp;
+  disabled?:boolean;
 }
-const FormikInput = ({ name, label, type, placeholder, icon }: IProps) => {
+const FormikInput = ({ name, label, type, placeholder, icon, disabled }: IProps) => {
   const [field, meta, helpers] = useField(name);
   const { value } = meta;
   const { setValue } = helpers;
@@ -27,8 +28,15 @@ const FormikInput = ({ name, label, type, placeholder, icon }: IProps) => {
         type={type || "text"}
         placeholder={placeholder ? placeholder : "Enter " + label}
         value={value || ""}
+        // onChange={(e) => setValue(e.target.value)}
+        // className='px-3 py-2 focus-theme rounded border border-slate-300 bg-slate-50 dark:bg-gray-900 text-black dark:text-gray-300'
         onChange={(e) => setValue(e.target.value)}
-        className='px-3 py-2 focus-theme rounded border border-slate-300 bg-slate-50 dark:bg-gray-900 text-black dark:text-gray-300'
+        disabled={disabled}
+        aria-disabled={disabled ? true : undefined}
+        className={
+          'px-3 py-2 focus-theme rounded border border-slate-300 bg-slate-50 dark:bg-gray-900 text-black dark:text-gray-300 ' +
+          (disabled ? 'opacity-60 cursor-not-allowed' : '')
+        }
       />
       {meta.touched && meta.error ? (
         <p className='text-orange-600 my-1 ml-1 inline-flex gap-1 items-center text-sm'>

--- a/src/pages/Settings/index.tsx
+++ b/src/pages/Settings/index.tsx
@@ -18,10 +18,17 @@ export function menuLinks(role: string | undefined) {
     case "admin":
       return {
         "Manage Users": { to: "users", icon: faUsersCog },
-        "Manage Tags": { to: "tags", icon: faTags },
+        // "Manage Tags": { to: "tags", icon: faTags },
         "API Credentials": { to: "credentials", icon: faKey },
         "Manage Sources": { to: "sources", icon: faCloudArrowDown },
       };
+    case "team_lead":
+      return {
+        "Manage Users": { to: "users", icon: faUsersCog },
+        // "Manage Tags": { to: "tags", icon: faTags },
+        "API Credentials": { to: "credentials", icon: faKey },
+        "Manage Sources": { to: "sources", icon: faCloudArrowDown },
+      };      
     case "monitor":
     case "viewer":
       return {

--- a/src/pages/Settings/source/SourceDetails.tsx
+++ b/src/pages/Settings/source/SourceDetails.tsx
@@ -48,7 +48,7 @@ const SourceDetails = () => {
     <div className=''>
       <div className='flex justify-between items-center my-3'>
         <h2 className='text-3xl font-medium'>{data?.nickname}</h2>
-        {session?.role === "admin" && (
+        { (session?.role === "admin" || session?.role === "team_lead") && (
           <div className='flex gap-4'>
             <PlaceholderDiv
               className='flex justify-end items-center gap-2'
@@ -111,7 +111,7 @@ const SourceDetails = () => {
           </div>
         </div>
 
-        { session?.role === "admin" &&
+        { (session?.role === "admin" || session?.role === "team_lead") &&
           <div className='grid grid-cols-4'>
             <p className='text-slate-600 dark:text-gray-400'>Credential</p>
             <div className='col-span-3'>

--- a/src/pages/Settings/source/SourcesIndex.tsx
+++ b/src/pages/Settings/source/SourcesIndex.tsx
@@ -64,7 +64,7 @@ const SourcesIndex = (props: IProps) => {
     <div className='mt-3'>
       <div className='flex justify-between items-center mt-3'>
         <h1 className='font-medium my-3 text-3xl'>Sources</h1>
-        { session?.role === "admin" &&
+        { (session?.role === "admin" || session?.role === "team_lead") &&
           <AggieButton
             onClick={() => setOpenCreate("new")}
             variant='primary'
@@ -75,7 +75,7 @@ const SourcesIndex = (props: IProps) => {
           </AggieButton>
         }
       </div>
-      { session?.role === "admin" && <Configuration /> }
+      { (session?.role === "admin" || session?.role === "team_lead") && <Configuration /> }
       <section className='bg-white dark:bg-gray-800 rounded-lg border border-slate-300 divide-y divide-slate-300 mt-3'>
         {data &&
           data.map((source) => (
@@ -95,7 +95,7 @@ const SourcesIndex = (props: IProps) => {
 
                 <p className='text-sm '>{source.keywords}</p>
               </main>
-              { session?.role === "admin" &&
+              { (session?.role === "admin" || session?.role === "team_lead") &&
                 <div>
                   <p className=' bg-slate-200 dark:bg-gray-600 rounded-full px-2  w-fit  py-1'>
                     <Link
@@ -129,7 +129,7 @@ const SourcesIndex = (props: IProps) => {
                   </Link>
                 </p>
               </div>
-              { session?.role === "admin" &&
+              { (session?.role === "admin" || session?.role === "team_lead") &&
                 <div className='flex justify-end items-center gap-2'>
                   <p className='text-xs font-medium text-slate-600 dark:text-gray-400'>
                     {source.enabled ? "Enabled" : "Disabled"}
@@ -180,7 +180,7 @@ const SourcesIndex = (props: IProps) => {
             </article>
           ))}
       </section>
-      { session?.role === "admin" && <>
+      { (session?.role === "admin" || session?.role === "team_lead") && <>
         <ConfirmationDialog
           isOpen={!!deletionModal}
           variant='danger'

--- a/src/pages/Settings/user/CreateEditUserForm.tsx
+++ b/src/pages/Settings/user/CreateEditUserForm.tsx
@@ -2,7 +2,7 @@ import * as Yup from "yup";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { newUser, editUser } from "../../../api/users";
-import { type User, USER_ROLES } from "../../../api/users/types";
+import { type User, USER_ROLES, UserRoles } from "../../../api/users/types";
 
 import { Form, Formik } from "formik";
 import FormikDropdown from "../../../components/FormikDropdown";
@@ -54,9 +54,10 @@ interface IProps {
   user?: User;
   onClose: () => void;
   canEditRole?: boolean;
+  currentUserRole?: UserRoles;
 }
 
-const CreateEditUserForm = ({ user, onClose, canEditRole }: IProps) => {
+const CreateEditUserForm = ({ user, onClose, canEditRole, currentUserRole }: IProps) => {
   const queryClient = useQueryClient();
 
   const doCreateUser = useMutation(newUser, {
@@ -74,6 +75,9 @@ const CreateEditUserForm = ({ user, onClose, canEditRole }: IProps) => {
   });
 
   function onSubmitForm(data: editSchema | createSchema) {
+    if (user && currentUserRole === 'team_lead') {
+      return; 
+    }
     if (!user) {
       doCreateUser.mutate(data);
     } else {
@@ -83,6 +87,11 @@ const CreateEditUserForm = ({ user, onClose, canEditRole }: IProps) => {
   }
 
   const isLoading = doCreateUser.isLoading || doEditUser.isLoading;
+  const isCreate = !user;
+  const isTeamLead = currentUserRole === 'team_lead';
+  
+  const allowedRoleList = (isCreate && isTeamLead) ? (['viewer','monitor']) : USER_ROLES;
+  const inputsDisabled = isLoading || (!!user && isTeamLead);
 
   const schema = !user ? userCreateSchema : userEditSchema;
   const defaultUser = !user
@@ -105,28 +114,30 @@ const CreateEditUserForm = ({ user, onClose, canEditRole }: IProps) => {
           label='Role'
           name='role'
           list={
-            user
-            ? (canEditRole
-                ? [...USER_ROLES].map(r => ({_id: r, label: r}))
-                : [{_id: user.role, label: user.role}])
-            : [...USER_ROLES].map(r => ({_id: r, label: r}))
-          }
-          disabled={user ? !canEditRole : false}
+              user
+                ? ( (canEditRole && !isTeamLead) // team_lead can’t edit role (or anything)
+                      ? [...USER_ROLES].map(r => ({ _id: r, label: r }))
+                      : [{ _id: user.role, label: user.role }] )
+                : allowedRoleList.map(r => ({ _id: r, label: r }))
+            }
+            disabled={user ? (!canEditRole || isTeamLead) : inputsDisabled}
         />
-        <FormikInput label='Username' name='username' />
+        <FormikInput label='Username' name='username' disabled={inputsDisabled}/>
         <FormikInput
           label='Display Name'
           name='displayName'
           placeholder='(optional) display name'
+          disabled={inputsDisabled}
         />
-        <FormikInput label='Email' name='email' type='email' />
+        <FormikInput label='Email' name='email' type='email' disabled={inputsDisabled} />
         {!user && (
           <>
-            <FormikInput name='password' label='Password' type='password' />
+            <FormikInput name='password' label='Password' type='password' disabled={inputsDisabled}/>
             <FormikInput
               name='confirmPassword'
               label='Re-type Password'
               type='password'
+              disabled={inputsDisabled}
             />
           </>
         )}
@@ -141,13 +152,18 @@ const CreateEditUserForm = ({ user, onClose, canEditRole }: IProps) => {
           </AggieButton>
           <AggieButton
             variant='primary'
-            disabled={isLoading}
+            disabled={isLoading || inputsDisabled}
             loading={isLoading}
             type={"submit"}
           >
             Confirm
           </AggieButton>
         </div>
+        {user && isTeamLead && (
+          <div className="text-sm text-red-500">
+            Team leads cannot edit users. Try delete and re-create users.
+          </div>
+        )}
       </Form>
     </Formik>
   );

--- a/src/pages/Settings/user/UserProfile.tsx
+++ b/src/pages/Settings/user/UserProfile.tsx
@@ -20,6 +20,7 @@ import {
   faUserShield,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { UserRoles } from "../../../api/users/types";
 
 interface IProps {
   session: Session | undefined;
@@ -44,7 +45,15 @@ const UserProfile = ({ session }: IProps) => {
   });
 
   const isSelf = session?._id === params.id;
-  const canEditRole = session?.role === "admin" && !isSelf;
+  const role = session?.role as UserRoles | undefined;
+  const isAdmin = role === 'admin';
+  const isTeamLead = role === 'team_lead';
+  const canEdit = !!isSelf || (isAdmin && !isSelf);
+  const canEditRole = isAdmin && !isSelf;
+  const canDeleteAsTeamLead = isTeamLead && !!data && String(data.createdBy) === String(session?._id) && !isSelf;
+  const canDeleteAsAdmin = isAdmin && !isSelf;
+  const canDelete = canDeleteAsAdmin || canDeleteAsTeamLead;
+  const showMenu = !!(isSelf || isAdmin || (isTeamLead && !!data && String(data.createdBy) === String(session?._id)));
 
   const grid = "grid grid-cols-4 py-1 items-center";
 
@@ -53,34 +62,40 @@ const UserProfile = ({ session }: IProps) => {
       <div className={`p-3 bg-white dark:bg-gray-800 rounded-xl border border-slate-300`}>
         <div className='flex justify-between items-center'>
           <h2 className='text-3xl font-medium'>{isSelf && "Your "}Profile</h2>
-          {(isSelf || session?.role === "admin") && (
+          {showMenu && (
             <DropdownMenu
               variant='secondary'
               className='px-2 py-1 rounded-lg bg-slate-100 dark:bg-gray-700 border border-slate-300 dark:hover:bg-gray-700'
               panelClassName='overflow-hidden right-0 text-sm'
               buttonElement={<FontAwesomeIcon icon={faEllipsisH} />}
             >
-              <AggieButton
-                className='px-3 py-2 hover:bg-slate-100 dark:hover:bg-gray-700 text-slate-600 dark:text-gray-400 w-full dark:text-gray-300'
-                onClick={() => setOpenEdit(true)}
-              >
-                <FontAwesomeIcon icon={faEdit} />
-                Edit
-              </AggieButton>
-              <AggieButton
-                className='px-3 py-2 hover:bg-slate-100 dark:hover:bg-gray-700 text-slate-600 dark:text-gray-400 w-full dark:text-gray-300'
-                onClick={() => setOpenEditPassword(true)}
-              >
-                <FontAwesomeIcon icon={faUserShield} />
-                Change Password
-              </AggieButton>
-              <AggieButton
-                className='px-3 py-2 hover:bg-slate-100 dark:hover:bg-gray-700 text-red-600'
-                onClick={() => setOpenDelete(true)}
-              >
-                <FontAwesomeIcon icon={faTrashAlt} />
-                Permanently Delete
-              </AggieButton>
+              {canEdit && (
+                <>
+                  <AggieButton
+                    className='px-3 py-2 hover:bg-slate-100 dark:hover:bg-gray-700 text-slate-600 dark:text-gray-400 w-full dark:text-gray-300'
+                    onClick={() => setOpenEdit(true)}
+                  >
+                    <FontAwesomeIcon icon={faEdit} />
+                    Edit
+                  </AggieButton>
+                  <AggieButton
+                    className='px-3 py-2 hover:bg-slate-100 dark:hover:bg-gray-700 text-slate-600 dark:text-gray-400 w-full dark:text-gray-300'
+                    onClick={() => setOpenEditPassword(true)}
+                  >
+                    <FontAwesomeIcon icon={faUserShield} />
+                    Change Password
+                  </AggieButton>
+                </>
+              )}
+              {canDelete && (
+                <AggieButton
+                  className='px-3 py-2 hover:bg-slate-100 dark:hover:bg-gray-700 text-red-600'
+                  onClick={() => setOpenDelete(true)}
+                >
+                  <FontAwesomeIcon icon={faTrashAlt} />
+                    Permanently Delete
+                </AggieButton>
+              )}
             </DropdownMenu>
           )}
         </div>
@@ -123,7 +138,8 @@ const UserProfile = ({ session }: IProps) => {
         <CreateEditUserForm 
           user={data} 
           onClose={() => setOpenEdit(false)} 
-          canEditRole = {canEditRole}
+          canEditRole={canEditRole}
+          currentUserRole={role}
         />
       </AggieDialog>
       <AggieDialog

--- a/src/pages/Settings/user/UsersIndex.tsx
+++ b/src/pages/Settings/user/UsersIndex.tsx
@@ -21,6 +21,7 @@ import {
   faTrashAlt,
   faUserShield,
 } from "@fortawesome/free-solid-svg-icons";
+import { UserRoles } from "../../../api/users/types";
 
 interface IProps {
   session?: Session;
@@ -73,7 +74,17 @@ const UsersIndex = ({ session }: IProps) => {
           <div className='flex justify-end '></div>
         </div>
         {!!data ? (
-          data.map((user) => (
+          data.map((user) => {
+            const role = session?.role as UserRoles | undefined;
+            const isAdmin = role === 'admin';
+            const isTeamLead = role === 'team_lead';
+            const isSelf = user._id === session?._id;
+            const canEditRow = isAdmin && !isSelf; // edit & change password allowed here
+            const canDeleteAsAdmin = isAdmin && !isSelf;
+            const canDeleteAsTeamLead = isTeamLead && !isSelf && String(user.createdBy) === String(session?._id);
+            const canDeleteRow = canDeleteAsAdmin || canDeleteAsTeamLead;
+            const showMenuRow = canEditRow || canDeleteRow;
+            return (
             <article
               key={user._id}
               className='grid grid-cols-4 px-3 py-3 items-center'
@@ -105,13 +116,15 @@ const UsersIndex = ({ session }: IProps) => {
               </p>
               <p>{user.email}</p>
               <div className='flex justify-end'>
-                {session?.role === "admin" && (
+                {showMenuRow  && (
                   <DropdownMenu
                     variant='secondary'
                     className='px-2 py-1 rounded-lg bg-slate-100 dark:bg-gray-700 border border-slate-300'
                     panelClassName='overflow-hidden right-0 text-sm'
                     buttonElement={<FontAwesomeIcon icon={faEllipsisH} />}
                   >
+                  {canEditRow && (
+                    <>
                     <AggieButton
                       className='px-3 py-2 hover:bg-slate-100 dark:hover:bg-gray-700 text-slate-600 dark:text-gray-400 w-full'
                       onClick={() => setEditUser(user._id)}
@@ -126,6 +139,9 @@ const UsersIndex = ({ session }: IProps) => {
                       <FontAwesomeIcon icon={faUserShield} />
                       Change Password
                     </AggieButton>
+                    </>
+                  )}
+                  {canDeleteRow && (
                     <AggieButton
                       className='px-3 py-2 hover:bg-slate-100 dark:hover:bg-gray-700 text-red-600'
                       onClick={() => setRemoveUser(user._id)}
@@ -133,11 +149,12 @@ const UsersIndex = ({ session }: IProps) => {
                       <FontAwesomeIcon icon={faTrashAlt} />
                       Permanently Delete
                     </AggieButton>
+                  )}
                   </DropdownMenu>
                 )}
               </div>
             </article>
-          ))
+          )})
         ) : (
           <article className='grid py-6 font-medium w-full place-items-center'>
             <p className=''>
@@ -162,6 +179,7 @@ const UsersIndex = ({ session }: IProps) => {
           user={userToEdit}
           onClose={() => setEditUser("")}
           canEditRole = {!! canEditRole}
+          currentUserRole={session?.role as UserRoles | undefined}
         />
       </AggieDialog>
       <AggieDialog


### PR DESCRIPTION
### What
Add new role (team lead) to current Role-based Access Control Model. Closes #76 
Team lead is able to: 
1. view/create/delete own-created users
2. view/create/edit sources/credentials
3. all other authorization to monitor role

### Changes
Backend:
1. model/user
2. controllers/userController
3. routes/userRoutes

Frontend:
1. component/CreateEditUserForm
2. page/UserProfile
3. page/UserIndex
4. page/Settings/index
5. page/SourceDetail & page/SourceIndex 