### PR TITLE
Feat: incident duration auto-populating

### DIFF
--- a/backend/api/controllers/groupController.js
+++ b/backend/api/controllers/groupController.js
@@ -90,29 +90,76 @@ exports.group_details = (req, res) => {
 };
 
 // Update a Group
-exports.group_update = (req, res, next) => {
-  // Find group to update
-  Group.findById(req.params._id, (err, group) => {
-    if (err) return res.status(err.status).send(err.message);
+exports.group_update = async (req, res) => {
+  try {
+    const group = await Group.findById(req.params._id);
     if (!group) return res.sendStatus(404);
-    // Update the actual values
 
-    group = _.extend(group, _.omit(req.body, 'creator'));
-    // Save group
-    group.save(function (err, numberAffected) {
-      if (err) {
-        res.status(err.status).send(err.message);
-      } else if (!numberAffected) {
-        res.sendStatus(404);
-      } else {
-        
-        eventRouter.publish('groups:update', { ids: group._id, update: group }).then(() => {
-          res.status(200).send(group);
-        });
-      }
+    const getTimeOrNull = (v) => {
+      if (!v) return null;
+      const d = v instanceof Date ? v : new Date(v);
+      const t = d.getTime();
+      return Number.isNaN(t) ? null : t;
+    };
+
+    const prevStartTs = getTimeOrNull(group.incidentStartedAt);
+    const prevEndTs   = getTimeOrNull(group.incidentEndedAt);
+
+    const safeBody = _.omit(req.body, ['creator', 'incidentDurationMs']);
+    _.extend(group, safeBody);
+
+    const newStartTs = getTimeOrNull(group.incidentStartedAt);
+    const newEndTs   = getTimeOrNull(group.incidentEndedAt);
+
+    let durationMs = null;
+    if (newStartTs !== null && newEndTs !== null && newEndTs >= newStartTs) {
+      durationMs = newEndTs - newStartTs;
+    }
+
+    group.incidentDurationMs = durationMs;
+
+    const saved = await group.save();
+    if (!saved) {
+      return res.sendStatus(404);
+    }
+
+    await eventRouter.publish('groups:update', {
+      ids: group._id,
+      update: group,   
     });
-  });
+
+    return res.status(200).send(group);
+  } catch (err) {
+    console.error('Error in group_update:', err);
+    return res
+      .status(err.status || 500)
+      .send(err.message || 'Error updating group');
+  }
 };
+
+// exports.group_update = (req, res, next) => {
+//   // Find group to update
+//   Group.findById(req.params._id, (err, group) => {
+//     if (err) return res.status(err.status).send(err.message);
+//     if (!group) return res.sendStatus(404);
+//     // Update the actual values
+
+//     group = _.extend(group, _.omit(req.body, 'creator'));
+//     // Save group
+//     group.save(function (err, numberAffected) {
+//       if (err) {
+//         res.status(err.status).send(err.message);
+//       } else if (!numberAffected) {
+//         res.sendStatus(404);
+//       } else {
+        
+//         eventRouter.publish('groups:update', { ids: group._id, update: group }).then(() => {
+//           res.status(200).send(group);
+//         });
+//       }
+//     });
+//   });
+// };
 
 // Delete selected groups
 exports.group_selected_delete = (req, res) => {

--- a/backend/api/controllers/groupController.js
+++ b/backend/api/controllers/groupController.js
@@ -111,12 +111,13 @@ exports.group_update = async (req, res) => {
     const newStartTs = getTimeOrNull(group.incidentStartedAt);
     const newEndTs   = getTimeOrNull(group.incidentEndedAt);
 
-    let durationMs = null;
+    let durationSeconds = null;
     if (newStartTs !== null && newEndTs !== null && newEndTs >= newStartTs) {
-      durationMs = newEndTs - newStartTs;
+      const durationMs = newEndTs - newStartTs;
+      durationSeconds = Math.floor(durationMs / 1000); 
     }
-
-    group.incidentDurationMs = durationMs;
+    
+    group.incidentDurationSeconds = durationSeconds;
 
     const saved = await group.save();
     if (!saved) {

--- a/backend/api/controllers/reportController.js
+++ b/backend/api/controllers/reportController.js
@@ -11,6 +11,7 @@ var _ = require('lodash');
 var tags = require('../../shared/tags');
 const Group = require("../../models/group");
 const eventRouter = require('../sockets/event-router');
+const {  recomputeIncidentDurationForGroups } = require('../utils/incidentDuration');
 
 // Determine the search keywords
 const parseQueryData = (queryString) => {
@@ -317,12 +318,35 @@ exports.reports_group_update = async (req, res) => {
 
     await group.save();
 
+    // recomputate and update incident duration fields (startedAt / endedAt / duration)
+    const groupIdsToRecompute = new Set([
+      ...prevGroupIds,
+      targetGroupId,
+    ]);
+    if (groupIdsToRecompute.size > 0) {
+      await recomputeIncidentDurationForGroups([...groupIdsToRecompute]);
+    }
+
+    const updatedTargetGroup = await Group.findById(targetGroupId)
+      .select(
+        '_id _reports impactedAsns impactedGeoScopes incidentStartedAt incidentEndedAt incidentDurationSeconds'
+      )
+      .lean()
+      .exec();
+
+    if (!updatedTargetGroup) {
+      return res.sendStatus(200);
+    }
+
     await eventRouter.publish('groups:update', {
       ids: [group._id],
       update: {
         _reports: group._reports,
         impactedAsns: group.impactedAsns || [],
         impactedGeoScopes: group.impactedGeoScopes || [],
+        incidentStartedAt: updatedTargetGroup.incidentStartedAt || null,
+        incidentEndedAt: updatedTargetGroup.incidentEndedAt || null,
+        incidentDurationSeconds: updatedTargetGroup.incidentDurationSeconds ?? null,
       },
     });
 
@@ -341,37 +365,95 @@ exports.reports_group_update = async (req, res) => {
     }
   }
 };
-// exports.reports_group_update = (req, res) => {
+
+// remove selected reports from one group
+exports.reports_group_remove = async (req, res) => {
+  try {
+    const ids = req.body.ids;
+    const groupPayload = req.body.group;
+
+    if (!ids || !ids.length) return res.sendStatus(200);
+    if (!groupPayload || !groupPayload._id) {
+      return res.status(400).send('Group is required');
+    }
+
+    const groupId = groupPayload._id.toString();
+
+    const reports = await Report.find({ _id: { $in: ids } });
+    if (!reports.length) return res.sendStatus(200);
+
+    for (const report of reports) {
+      report._group = undefined;
+      await report.save();
+    }
+
+    const group = await Group.findById(groupId);
+    if (!group) {
+      return res.status(404).send('Group not found');
+    }
+
+    if (!Array.isArray(group._reports)) group._reports = [];
+
+    const idsSet = new Set(ids.map((id) => id.toString()));
+
+    group._reports = group._reports.filter(
+      (rid) => !idsSet.has(rid.toString())
+    );
+
+    await group.save();
+
+    await recomputeIncidentDurationForGroups([groupId]);
+
+    const updatedGroup = await Group.findById(groupId)
+      .select(
+        '_id _reports impactedAsns impactedGeoScopes incidentStartedAt incidentEndedAt incidentDurationSeconds'
+      )
+      .lean()
+      .exec();
+
+    if (!updatedGroup) {
+      return res.sendStatus(200);
+    }
+
+    await eventRouter.publish('groups:update', {
+      ids: [updatedGroup._id],
+      update: {
+        _reports: updatedGroup._reports,
+        impactedAsns: updatedGroup.impactedAsns || [],
+        impactedGeoScopes: updatedGroup.impactedGeoScopes || [],
+        incidentStartedAt: updatedGroup.incidentStartedAt || null,
+        incidentEndedAt: updatedGroup.incidentEndedAt || null,
+        incidentDurationSeconds: updatedGroup.incidentDurationSeconds ?? null,
+      },
+    });
+
+    await eventRouter.publish('reports:update', {
+      ids,
+      update: { _group: null },
+    });
+
+    return res.sendStatus(200);
+  } catch (err) {
+    console.error('Error in reports_group_remove', err);
+    if (!res.headersSent) {
+      res
+        .status(err.status || 500)
+        .send(err.message || 'Error removing reports from group');
+    }
+  }
+};
+
+
+// exports.reports_group_remove = (req, res) => {
 //   if (!req.body.ids || !req.body.ids.length) return res.sendStatus(200);
 //   Report.find({ _id: { $in: req.body.ids } }, (err, reports) => {
 //     if (err) return res.status(err.status).send(err.message);
 //     if (reports.length === 0) return res.sendStatus(200);
 //     let remaining = reports.length;
+
+
 //     reports.forEach((report) => {
-//       //  report.read = true;
-//       let prevGroupId = null;
-//       // remove report from previous group, if any
-//       if(report._group) {
-//         prevGroupId = report._group;
-//         Group.findById(prevGroupId, (err, group) => {
-//           if (err) {
-//             if (!res.headersSent) {
-//               return res.status(err.status).send(err.message);
-//             }
-//             return;
-//           }
-//           group._reports.pull(report._id);
-//           group.save((err) => {
-//             if (err) {
-//               if (!res.headersSent) return res.status(err.status).send(err.message)
-//               return;
-//             }
-//           })
-//         })
-//       }
-//       // map report with group
-//       report._group = req.body.group._id;
-//       report.read = true;
+//       report._group = undefined;
 //       report.save((err) => {
 //         if (err) {
 //           if (!res.headersSent) return res.status(err.status).send(err.message)
@@ -384,22 +466,32 @@ exports.reports_group_update = async (req, res) => {
 //             }
 //             return;
 //           }
-//           group._reports.push(report._id);
+//           group._reports = group._reports.filter(i => i.equals(report._id));
+
 //           group.save((err) => {
 //             if (err) {
 //               if (!res.headersSent) return res.status(err.status).send(err.message)
 //               return;
+
 //             }
 //             if (--remaining === 0) {
-//               eventRouter.publish('groups:update', { ids: [req.body.group._id], update: { _reports: group._reports } }).then(() => {
+//               eventRouter.publish('groups:update', { 
+//                   ids: [req.body.group._id], 
+//                   update: { 
+//                     _reports: group._reports,
+//                     impactedAsns: group.impactedAsns || [],
+//                     impactedGeoScopes: group.impactedGeoScopes || [],
+//                   } 
+//                 }).then(() => {
 //                 return res.sendStatus(200)
 //               });
 //             }
+
 //           })
 //         })
         
 //         if (--remaining === 0) {
-//           eventRouter.publish('reports:update', { ids: req.body.ids, update: { _group: req.body.group._id, read: true } }).then(() => {
+//           eventRouter.publish('reports:update', { ids: req.body.ids, update: { _group: req.body.group._id } }).then(() => {
 //             return res.sendStatus(200)
 //           });
 
@@ -408,63 +500,7 @@ exports.reports_group_update = async (req, res) => {
 //     });
 //   });
 // }
-// remove selected reports from one group
-exports.reports_group_remove = (req, res) => {
-  if (!req.body.ids || !req.body.ids.length) return res.sendStatus(200);
-  Report.find({ _id: { $in: req.body.ids } }, (err, reports) => {
-    if (err) return res.status(err.status).send(err.message);
-    if (reports.length === 0) return res.sendStatus(200);
-    let remaining = reports.length;
 
-
-    reports.forEach((report) => {
-      report._group = undefined;
-      report.save((err) => {
-        if (err) {
-          if (!res.headersSent) return res.status(err.status).send(err.message)
-          return;
-        }
-        Group.findById(req.body.group._id, (err, group) => {
-          if (err) {
-            if (!res.headersSent) {
-              return res.status(err.status).send(err.message);
-            }
-            return;
-          }
-          group._reports = group._reports.filter(i => i.equals(report._id));
-
-          group.save((err) => {
-            if (err) {
-              if (!res.headersSent) return res.status(err.status).send(err.message)
-              return;
-
-            }
-            if (--remaining === 0) {
-              eventRouter.publish('groups:update', { 
-                  ids: [req.body.group._id], 
-                  update: { 
-                    _reports: group._reports,
-                    impactedAsns: group.impactedAsns || [],
-                    impactedGeoScopes: group.impactedGeoScopes || [],
-                  } 
-                }).then(() => {
-                return res.sendStatus(200)
-              });
-            }
-
-          })
-        })
-        
-        if (--remaining === 0) {
-          eventRouter.publish('reports:update', { ids: req.body.ids, update: { _group: req.body.group._id } }).then(() => {
-            return res.sendStatus(200)
-          });
-
-        };
-      });
-    });
-  });
-}
 // Update Notes
 exports.reports_notes_update = (req, res) => {
   if (!req.body.ids || !req.body.ids.length) return res.sendStatus(200);

--- a/backend/api/utils/incidentDuration.js
+++ b/backend/api/utils/incidentDuration.js
@@ -1,0 +1,96 @@
+'use strict';
+
+const Group = require('../../models/group');
+const Report = require('../../models/report');
+
+/**
+ * Given a set of reports, compute:
+ *   - earliest outageStartedAt/authoredAt (minStart)
+ *   - latest outageEndedAt (maxEnd)
+ *   - duration in seconds (or null if we don't have a closed interval)
+ */
+function computeIncidentTimeBoundsFromReports(reports) {
+  let minStart = null;
+  let maxEnd = null;
+
+  for (const r of reports) {
+    const start = r.outageStartedAt || r.authoredAt || null;
+    if (start instanceof Date && !Number.isNaN(start.getTime())) {
+      if (!minStart || start < minStart) {
+        minStart = start;
+      }
+    }
+
+    const end = r.outageEndedAt;
+    if (end instanceof Date && !Number.isNaN(end.getTime())) {
+      if (!maxEnd || end > maxEnd) {
+        maxEnd = end;
+      }
+    }
+  }
+
+  let durationSeconds = null;
+  if (minStart && maxEnd) {
+    durationSeconds = Math.floor((maxEnd.getTime() - minStart.getTime()) / 1000);
+    if (durationSeconds < 0) {
+      durationSeconds = null;
+    }
+  }
+
+  return { minStart, maxEnd, durationSeconds };
+}
+
+/**
+ * Recompute incidentStartedAt, incidentEndedAt, and incidentDurationSeconds
+ * for a single group, based on its member reports.
+ */
+async function recomputeIncidentDurationForGroup(groupId) {
+  if (!groupId) return;
+
+  const group = await Group.findById(groupId);
+  if (!group) return;
+
+  if (!Array.isArray(group._reports) || group._reports.length === 0) {
+    group.incidentStartedAt = null;
+    group.incidentEndedAt = null;
+    group.incidentDurationSeconds = null;
+    await group.save();
+    return;
+  }
+
+  const reports = await Report.find({ _id: { $in: group._reports } })
+    .select('outageStartedAt outageEndedAt authoredAt')
+    .lean()
+    .exec();
+
+  const { minStart, maxEnd, durationSeconds } =
+    computeIncidentTimeBoundsFromReports(reports);
+
+  group.incidentStartedAt = minStart || null;
+  group.incidentEndedAt = maxEnd || null;
+  group.incidentDurationSeconds = durationSeconds;
+
+  await group.save();
+}
+
+/**
+ * Batch recompute fields for multiple groups 
+ */
+async function recomputeIncidentDurationForGroups(groupIds) {
+  if (!groupIds || !groupIds.length) return;
+  const uniqueIds = [...new Set(groupIds.map((id) => id.toString()))];
+
+  for (const gid of uniqueIds) {
+    try {
+      await recomputeIncidentDurationForGroup(gid);
+    } catch (err) {
+      console.warn('[incidentDuration] Failed to recompute duration for group', gid, err);
+    }
+  }
+}
+
+module.exports = {
+  computeIncidentTimeBoundsFromReports,
+  recomputeIncidentDurationForGroup,
+  recomputeIncidentDurationForGroups,
+};

--- a/backend/fetching/channels/cloudflare.js
+++ b/backend/fetching/channels/cloudflare.js
@@ -5,6 +5,9 @@ const { default: SocialMediaPost } = require('downstream/build/builtin/post');
 const { mongoose } = require('../../database');
 const { API_BASE_URLS, API_ROUTES, DATA_SOURCES, API_LINKED_PAGE_URLS, API_MAX_RESULTS } = require('../../config/fetching/externalApis');
 const { decryptSecretsObject } = require('../utils/decryption');
+const {  recomputeIncidentDurationForGroups } = require('../../api/utils/incidentDuration');
+const Group = require('../../models/group');
+const Report = require('../../models/report');
 require('dotenv').config();
 
 const countries = require('i18n-iso-countries');
@@ -105,6 +108,7 @@ class CloudflareChannel extends PollChannel {
             let irrelevantRegionReportCount = 0;
             
             const collection = mongoose.connection.db.collection('reports');
+            const affectedGroupIds = new Set();
 
             // Parse and transform each event 
             for (const event of events) {
@@ -129,23 +133,30 @@ class CloudflareChannel extends PollChannel {
                 // De-duplicate fetched report for downstream tasks
                 try {
 
-                    const existingReport = await collection.findOne({ guid: formattedEvent.platformID });
+                    const existingReport = await Report.findOne({ guid: formattedEvent.platformID });
 
                     if (existingReport) {
+                        const prevEnd = existingReport.outageEndedAt
+                        ? existingReport.outageEndedAt.getTime()
+                        : null;
+                        const newEnd = formattedEvent.outageEndedAt
+                        ? formattedEvent.outageEndedAt.getTime()
+                        : null;
 
-                        await collection.updateOne(
-                            { guid: formattedEvent.platformID },
-                            {
-                                // update existing report if fields updated (such as endDate confirmed)
-                                $set: {
-                                    content: formattedEvent.content,
-                                    url: formattedEvent.url,
-                                    'metadata.rawAPIResponse': formattedEvent.raw,
-                                }
-                            }
-                        );
+                        const endChanged = prevEnd !== newEnd;
 
+                        // update fields
+                        existingReport.content = formattedEvent.content;
+                        existingReport.url = formattedEvent.url;
+                        existingReport.metadata.rawAPIResponse = formattedEvent.raw;
+                        existingReport.outageEndedAt = formattedEvent.outageEndedAt;
+
+                        await existingReport.save();
                         existedReportCount += 1;
+
+                        if (endChanged && existingReport._group) {
+                            affectedGroupIds.add(existingReport._group.toString());
+                        }
 
                     } else {
 
@@ -164,6 +175,12 @@ class CloudflareChannel extends PollChannel {
             }
 
             console.log(`[Fetching-channel-Cloudflare] Success - Parsed and formatted data from url: ${url}, total records: ${events.length}, new records: ${newReportCount}, existed records: ${existedReportCount}, irrelevant region records: ${irrelevantRegionReportCount}.`);
+            
+            if (affectedGroupIds.size > 0) {
+                // console.log(`[Cloudflare] Recomputing duration for ${affectedGroupIds.size} affected incidents`);
+                await recomputeIncidentDurationForGroups([...affectedGroupIds]);
+            }
+
         } catch (e) {
             console.error(`[Fetching-channel-Cloudflare] Failed - Failed parsing and formating data: ${this.options.media}.`);
         }

--- a/backend/fetching/channels/cloudflare.js
+++ b/backend/fetching/channels/cloudflare.js
@@ -148,8 +148,12 @@ class CloudflareChannel extends PollChannel {
                         // update fields
                         existingReport.content = formattedEvent.content;
                         existingReport.url = formattedEvent.url;
-                        existingReport.metadata.rawAPIResponse = formattedEvent.raw;
                         existingReport.outageEndedAt = formattedEvent.outageEndedAt;
+                        // update whole metadata.rawAPIResponse object
+                        existingReport.metadata = existingReport.metadata || {};
+                        existingReport.metadata.rawAPIResponse = formattedEvent.raw;
+                        existingReport.markModified('metadata');
+
 
                         await existingReport.save();
                         existedReportCount += 1;

--- a/backend/fetching/channels/ioda.js
+++ b/backend/fetching/channels/ioda.js
@@ -190,9 +190,12 @@ class IODAChannel extends PollChannel {
                             // update fields
                             existingReport.content = formattedEvent.content;
                             existingReport.url = formattedEvent.url;
-                            existingReport.metadata.rawAPIResponse = formattedEvent.raw;
                             existingReport.outageEndedAt = formattedEvent.outageEndedAt;
-
+                            // update whole metadata.rawAPIResponse object
+                            existingReport.metadata = existingReport.metadata || {};
+                            existingReport.metadata.rawAPIResponse = formattedEvent.raw;
+                            existingReport.markModified('metadata');
+                            
                             await existingReport.save();
                             existedReportCount += 1;
 

--- a/backend/fetching/channels/ioda.js
+++ b/backend/fetching/channels/ioda.js
@@ -4,6 +4,9 @@ const { mongoose } = require('../../database');
 const REGION_CODES = require('../../config/fetching/channels/iodaMappings');
 const { API_BASE_URLS, API_ROUTES, DATA_SOURCES, API_LINKED_PAGE_URLS } = require('../../config/fetching/externalApis');
 const extractCleanSVGFromPage = require('../utils/iodaUtils');
+const {  recomputeIncidentDurationForGroups } = require('../../api/utils/incidentDuration');
+const Group = require('../../models/group');
+const Report = require('../../models/report');
 const { chromium } = require('playwright');
 const countries = require('i18n-iso-countries');
 require('dotenv').config();
@@ -146,6 +149,7 @@ class IODAChannel extends PollChannel {
                 this.linkedPageCache = {}; // avoid duplicately extract graph components
 
                 const collection = mongoose.connection.db.collection('reports');
+                const affectedGroupIds = new Set();
 
                 // Parse and transform each event 
                 for (const event of events) {
@@ -171,24 +175,30 @@ class IODAChannel extends PollChannel {
 
                     // De-duplicate fetched report for downstream tasks
                     try {
-
-                        const existingReport = await collection.findOne({ guid: formattedEvent.platformID });
+                        const existingReport = await Report.findOne({ guid: formattedEvent.platformID });
 
                         if (existingReport) {
+                            const prevEnd = existingReport.outageEndedAt
+                            ? existingReport.outageEndedAt.getTime()
+                            : null;
+                            const newEnd = formattedEvent.outageEndedAt
+                            ? formattedEvent.outageEndedAt.getTime()
+                            : null;
 
-                            await collection.updateOne(
-                                { guid: formattedEvent.platformID },
-                                {
-                                    // update existing report if fields updated (such as endDate confirmed)
-                                    $set: {
-                                        content: formattedEvent.content,
-                                        url: formattedEvent.url,
-                                        'metadata.rawAPIResponse': formattedEvent.raw,
-                                    }
-                                }
-                            );
+                            const endChanged = prevEnd !== newEnd;
 
+                            // update fields
+                            existingReport.content = formattedEvent.content;
+                            existingReport.url = formattedEvent.url;
+                            existingReport.metadata.rawAPIResponse = formattedEvent.raw;
+                            existingReport.outageEndedAt = formattedEvent.outageEndedAt;
+
+                            await existingReport.save();
                             existedReportCount += 1;
+
+                            if (endChanged && existingReport._group) {
+                                affectedGroupIds.add(existingReport._group.toString());
+                            }
 
                         } else {
                             // Add new report to downstream hooks
@@ -206,6 +216,11 @@ class IODAChannel extends PollChannel {
 
                 console.log(`[Fetching-channel-IODA] Success - Parsed and formatted data from url: ${url}, total records: ${events.length}, new records: ${newReportCount}, existed records: ${existedReportCount}, irrelevant region records: ${irrelevantRegionReportCount}.`);
 
+                if (affectedGroupIds.size > 0) {
+                    // console.log(`[IODA] Recomputing duration for ${affectedGroupIds.size} affected incidents`);
+                    await recomputeIncidentDurationForGroups([...affectedGroupIds]);
+                }
+
             } catch (e) {
                 console.error(`[Fetching-channel-IODA] Failed - Failed parsing and formating data: ${this.options.media} - ${queryType}.`);
             }
@@ -221,8 +236,7 @@ class IODAChannel extends PollChannel {
 
         return outages;
 
-    } finally {
-
+    } finally {       
         await this.browser.close(); // ensure closing headerless browser 
     }
 } 

--- a/backend/models/group.js
+++ b/backend/models/group.js
@@ -66,6 +66,7 @@ let schema = new mongoose.Schema({
   storedAt: { type: Date, index: true },
   incidentStartedAt: {type: Date, index: true},
   incidentEndedAt: { type: Date, index: true },
+  incidentDurationSeconds: { type: Number, default: null },
   impactedAsns: { type: [String], default:[] },
   impactedGeoScopes:{ type: [String], default:[] },
   tags: { type: [String], default: [] },

--- a/src/api/groups/types.ts
+++ b/src/api/groups/types.ts
@@ -39,6 +39,7 @@ export interface Group extends hasId {
   comments?: GroupComment[];
   incidentStartedAt: Date;
   incidentEndedAt: Date;
+  incidentDurationSeconds?: number | null; 
   impactedAsns?: string[]; 
   impactedGeoScopes?: string[];
 }

--- a/src/pages/incidents/CreateEditIncidentForm.tsx
+++ b/src/pages/incidents/CreateEditIncidentForm.tsx
@@ -149,8 +149,9 @@ const CreateEditIncidentForm = ({
             return { key: i, value: i };
           })}
         />
-        {/* show asn edit box only in edit mode */}
+        {/* show only in edit mode */}
         {group && (
+          <>
           <FormikMultiCombobox
             name='impactedAsns'
             unitLabel='ASN'
@@ -170,9 +171,6 @@ const CreateEditIncidentForm = ({
               }) || [{ key: "", value: "Loading ASNs…" }]
             }
           />
-        )}
-        {/* show geoScope edit box only in edit mode */}
-        {group && (
           <FormikMultiCombobox
             name='impactedGeoScopes'
             unitLabel='area'
@@ -182,17 +180,19 @@ const CreateEditIncidentForm = ({
               geoOptions?.map((g) => ({ key: g.key, value: g.value })) || []
             }
           />
+          <FormikDateTime
+            name='incidentStartedAt'
+            label='Incident Start Time (UTC)'
+            icon={faBackwardStep}
+          />
+          <FormikDateTime
+            name='incidentEndedAt'
+            label='Incident End Time (UTC)'
+            icon={faForwardStep}
+          />
+          </>
         )}
-        <FormikDateTime
-          name='incidentStartedAt'
-          label='Incident Start Time (UTC)'
-          icon={faBackwardStep}
-        />
-        <FormikDateTime
-          name='incidentEndedAt'
-          label='Incident End Time (UTC)'
-          icon={faForwardStep}
-        />
+
         {/* <FormikInput name='locationName' label='Location' icon={faCompass} /> hide from UI */}
 
         <label>

--- a/src/pages/incidents/Incident/IncidentInfo.tsx
+++ b/src/pages/incidents/Incident/IncidentInfo.tsx
@@ -21,6 +21,7 @@ import UserToken from "../../../components/UserToken";
 import { IncidentOverallStatus, IncidentStatuses } from "../IncidentStatuses";
 import { getAsnsByIds } from "../../../api/asn";
 import type { AsnInfoMap } from "../../../api/asn/types";
+import { formatDurationFromSeconds } from "../../../utils/format";
 
 
 interface IProps {
@@ -233,6 +234,22 @@ const IncidentInfo = ({ group, isLoading, onEdit }: IProps) => {
             </p>
           ) : (
             <p className='italic text-slate-600 dark:text-gray-400'>No Date Set</p>
+          )}
+        </PlaceholderDiv>
+      </div>
+
+      <div className='flex gap-2 items-center pt-2'>
+        <span className='whitespace-nowrap'>Incident Duration:</span>
+        <PlaceholderDiv
+          loading={isLoading}
+          className='flex flex-wrap gap-x-2 gap-y-1 items-center '
+        >
+          {typeof group?.incidentDurationSeconds === "number" && group.incidentDurationSeconds >= 0 ? (
+            <p className='whitespace-pre-line max-w-prose text-black dark:text-gray-300'>
+              {formatDurationFromSeconds(group.incidentDurationSeconds)}
+            </p>
+          ) : (
+            <p className='italic text-slate-600 dark:text-gray-400'>Ongoing</p>
           )}
         </PlaceholderDiv>
       </div>

--- a/src/utils/format.tsx
+++ b/src/utils/format.tsx
@@ -105,4 +105,31 @@ export function shortenString(s: string, left = 10, right = 10) {
     return s;
   } 
 }
-  
+
+export function formatIsoTime(iso: string | Date) {
+  if (!iso) return "Unknown Date";
+  const date = iso instanceof Date ? iso : new Date(iso);
+  if (Number.isNaN(date.getTime())) return "Unknown Date";
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(date.getUTCDate()).padStart(2, "0");
+  const hour = String(date.getUTCHours()).padStart(2, "0");
+  const minute = String(date.getUTCMinutes()).padStart(2, "0");
+  return `${year}-${month}-${day} ${hour}:${minute}`;
+}
+
+
+export function formatDurationFromSeconds(seconds?: number | null) {
+  if (seconds == null || seconds <= 0) return "Ongoing";
+
+  const days = Math.floor(seconds / 86400);
+  const hours = Math.floor((seconds % 86400) / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+
+  const parts: string[] = [];
+  if (days) parts.push(`${days}d`);
+  if (hours) parts.push(`${hours}h`);
+  if (minutes || (!days && !hours)) parts.push(`${minutes}m`);
+
+  return parts.join(" ");
+}


### PR DESCRIPTION
### What

closes #84 , new feature on Incident that:

Auto-populate incident duration based on logic: out of alerts attached to an incident upon creation, use the earliest start time and last end time from the alerts to pre-populate the start and end time.

### Changes

Backend

1. controllers & routes: adding logic to recompute incident duration when an incident's report members changed or member reports' end time changes
2. scripts & config: adding script to ingest ASN metadata
3. util functions: for quick calculating incident duration 

Frontend

1. pages/incidents/CreateEditIncidentForm.tsx
2. pages/incidents/incident/IncidentInfo.tsx
3. util functions for formatting incident data time and duration