### PR TITLE
Fix: Incident Duration Calculation Logic Update

### DIFF
--- a/backend/api/controllers/reportController.js
+++ b/backend/api/controllers/reportController.js
@@ -21,9 +21,9 @@ const parseQueryData = (queryString) => {
     'sourceId', 'groupId', 'author', 'tags', 'list', 'escalated', 'veracity', 'isRelevantReports', "irrelevant"]);
   
   if (!query.media && query.alerts === 'true') {
-     query.media = { $in: ['ioda', 'cloudflare'] };
+    query.isOutageEvent = true;
   } else if (!query.media && query.alerts === 'false') {
-      query.media = { $nin: ['ioda', 'cloudflare'] };
+    query.isOutageEvent = {$ne: true};
   } 
   
   

--- a/backend/api/utils/incidentDuration.js
+++ b/backend/api/utils/incidentDuration.js
@@ -14,6 +14,9 @@ function computeIncidentTimeBoundsFromReports(reports) {
   let maxEnd = null;
 
   for (const r of reports) {
+
+    if (!r.isOutageEvent) {continue};
+
     const start = r.outageStartedAt || r.authoredAt || null;
     if (start instanceof Date && !Number.isNaN(start.getTime())) {
       if (!minStart || start < minStart) {
@@ -59,7 +62,7 @@ async function recomputeIncidentDurationForGroup(groupId) {
   }
 
   const reports = await Report.find({ _id: { $in: group._reports } })
-    .select('outageStartedAt outageEndedAt authoredAt')
+    .select('isOutageEvent outageStartedAt outageEndedAt authoredAt')
     .lean()
     .exec();
 

--- a/backend/models/query/report-query.js
+++ b/backend/models/query/report-query.js
@@ -32,6 +32,7 @@ function ReportQuery(options) {
   this.notes = options.notes;
   this.isRelevantReports = options.isRelevantReports;
   this.irrelevant = options.irrelevant;
+  this.isOutageEvent = options.isOutageEvent;
 
 }
 
@@ -59,6 +60,7 @@ ReportQuery.prototype.toMongooseFilter = function () {
     escalated: this.escalated,
     veracity: this.veracity,
     aitagnames: this.aitagnames,
+    isOutageEvent: this.isOutageEvent,
   }
   if (this.groupId === "none") filter._group = { $eq: null }
   if (this.escalated === 'unescalated') filter.escalated = false;


### PR DESCRIPTION
### What

Fix incident duration calculation logic, including alert reports only.

###Changes

Backend
api/utils/incidentDuration: skip non-alert reports in duration calculation