### PR TITLE
Add backend foundation for team support

### DIFF
--- a/backend/api/controllers/teamController.js
+++ b/backend/api/controllers/teamController.js
@@ -1,0 +1,41 @@
+// Handles CRUD requests for teams.
+const Team = require('../../models/team');
+
+// Get all teams
+exports.team_list = (req, res) => {
+  if (!req.user) return res.status(401).send('Unauthenticated.');
+
+  Team.find({})
+    .sort({ name: 1 })
+    .lean()
+    .exec((err, teams) => {
+      if (err) {
+        return res
+          .status(err.status || 500)
+          .send(err.message || 'Team query failed');
+      }
+
+      return res.status(200).send(teams);
+    });
+};
+
+// Create a team
+exports.team_create = (req, res) => {
+  if (!req.user) return res.status(401).send('Unauthenticated.');
+
+  const payload = {
+    name: req.body.name,
+    description: req.body.description || '',
+    active: typeof req.body.active === 'boolean' ? req.body.active : true,
+  };
+
+  Team.create(payload, (err, team) => {
+    if (err) {
+      return res
+        .status(err.status || 500)
+        .send(err.message || 'Team creation failed');
+    }
+
+    return res.status(201).send(team);
+  });
+};

--- a/backend/api/middlewares/groupMiddlewares.js
+++ b/backend/api/middlewares/groupMiddlewares.js
@@ -1,5 +1,5 @@
 const multer = require('multer');
-const { MAX_ATTACHMENT_SIZE, MAX_ATTACHMENT_COUNT } = require('../../models/groupConfigs');
+const { MAX_ATTACHMENT_SIZE, MAX_ATTACHMENT_COUNT } = require('../../config/models/groupConfigs');
 
 const allowedMimeTypes = ['image/jpeg', 'image/png', 'application/pdf', 'text/csv', 'text/plain'];
 

--- a/backend/api/routes/apiRoutes.js
+++ b/backend/api/routes/apiRoutes.js
@@ -12,6 +12,7 @@ const tagRouter = require('./tagRoutes');
 const userRouter = require('./userRoutes');
 const searchRouter = require('./searchRoutes');
 const visualizationRouter = require('./visualizationRoutes');
+const teamRouter = require('./teamRoutes');
 
 // Add all API routes
 router.use('/asn', asnRouter);
@@ -26,6 +27,7 @@ router.use('/search', searchRouter);
 router.use('/tag', tagRouter);
 router.use('/user', userRouter);
 router.use('/visualization', visualizationRouter);
+router.use('/team', teamRouter);
 module.exports = router;
 
 

--- a/backend/api/routes/teamRoutes.js
+++ b/backend/api/routes/teamRoutes.js
@@ -1,0 +1,13 @@
+'use strict'
+const express = require('express');
+const router = express.Router();
+const teamController = require('../controllers/teamController');
+const User = require('../../models/user');
+
+// Get all teams
+router.get('', teamController.team_list);
+
+// Create a team
+router.post('', User.can('admin users'), teamController.team_create);
+
+module.exports = router;

--- a/backend/models/team.js
+++ b/backend/models/team.js
@@ -1,0 +1,24 @@
+const database = require('../database');
+const mongoose = database.mongoose;
+
+const teamSchema = new mongoose.Schema({
+  name: {
+    type: String,
+    required: true,
+    trim: true,
+    unique: true,
+    index: true,
+  },
+  description: {
+    type: String,
+    default: '',
+    trim: true,
+  },
+  active: {
+    type: Boolean,
+    default: true,
+    index: true,
+  },
+}, { timestamps: true });
+
+module.exports = mongoose.model('Team', teamSchema);

--- a/backend/models/user.js
+++ b/backend/models/user.js
@@ -41,6 +41,11 @@ var userSchema = new Schema({
   password: { type: String },
   hasDefaultPassword: { type: Boolean, default: true },
   role: { type: String, default: 'viewer' },
+  teams: {
+      type: [{ type: Schema.Types.ObjectId, ref: 'Team' }],
+      default: [],
+      index: true,
+  },
   active: { type: Boolean, default: true },
   attempts: { type: Number, default: 0 },
   last: { type: Date },


### PR DESCRIPTION
Description:
This PR adds the initial backend foundation for team-based access control.

Changes included:

Adds a new Team model.
Adds a teams field to the User model so users can belong to multiple teams.
Adds a basic team API route.
Supports listing teams.
Supports admin-only team creation.

This PR does not enforce team-based access control yet. It should not change existing access behavior for incidents, reports, sources, credentials, or other application data. This is intended as a low-risk foundation for future team membership and scoped-access work.