### PR TITLE
Fix/ioda svg media storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ build
 .env
 
 backend/api/uploads
+
+.claude/

--- a/backend/api/controllers/reportController.js
+++ b/backend/api/controllers/reportController.js
@@ -58,15 +58,26 @@ const serializeReport = (report) => {
       }))
     : plainReport?.metadata?.attachments;
 
-  // IODA charts are stored as a media key at metadata.rawAPIResponse.image; expose a
-  // URL the frontend can <img src> against. Guard the legacy inline-SVG shape (starts
-  // with '<') so pre-migration reports keep working.
+  // Chart images at metadata.rawAPIResponse.image come in three shapes; expose a URL
+  // the frontend can <img src> against without mangling remote URLs. The shapes are:
+  //   - legacy inline SVG (pre-migration IODA, starts with '<') — no URL, leave as-is
+  //   - absolute remote URL (Cloudflare Radar chart) — pass through unchanged
+  //   - relative media key (post-migration IODA) — resolve to /media/... via buildMediaUrl
   const rawAPIResponse = plainReport?.metadata?.rawAPIResponse;
-  const chartKey = rawAPIResponse?.image;
+  const chartImage = rawAPIResponse?.image;
+  let imageUrl;
+  if (typeof chartImage === 'string') {
+    const trimmed = chartImage.trimStart();
+    if (trimmed.startsWith('<')) {
+      imageUrl = undefined;
+    } else if (/^https?:\/\//i.test(trimmed)) {
+      imageUrl = chartImage;
+    } else {
+      imageUrl = buildMediaUrl(chartImage);
+    }
+  }
   const rawAPIResponseWithUrl =
-    chartKey && typeof chartKey === 'string' && !chartKey.trimStart().startsWith('<')
-      ? { ...rawAPIResponse, imageUrl: buildMediaUrl(chartKey) }
-      : rawAPIResponse;
+    imageUrl != null ? { ...rawAPIResponse, imageUrl } : rawAPIResponse;
 
   return {
     ...plainReport,

--- a/backend/api/controllers/reportController.js
+++ b/backend/api/controllers/reportController.js
@@ -58,12 +58,23 @@ const serializeReport = (report) => {
       }))
     : plainReport?.metadata?.attachments;
 
+  // IODA charts are stored as a media key at metadata.rawAPIResponse.image; expose a
+  // URL the frontend can <img src> against. Guard the legacy inline-SVG shape (starts
+  // with '<') so pre-migration reports keep working.
+  const rawAPIResponse = plainReport?.metadata?.rawAPIResponse;
+  const chartKey = rawAPIResponse?.image;
+  const rawAPIResponseWithUrl =
+    chartKey && typeof chartKey === 'string' && !chartKey.trimStart().startsWith('<')
+      ? { ...rawAPIResponse, imageUrl: buildMediaUrl(chartKey) }
+      : rawAPIResponse;
+
   return {
     ...plainReport,
     metadata: plainReport?.metadata
       ? {
           ...plainReport.metadata,
           attachments,
+          ...(rawAPIResponse ? { rawAPIResponse: rawAPIResponseWithUrl } : {}),
         }
       : plainReport?.metadata,
   };

--- a/backend/api/controllers/reportController.js
+++ b/backend/api/controllers/reportController.js
@@ -104,6 +104,11 @@ exports.report_reports = (req, res) => {
     }
 
     const handler = (err, reports) => {
+      // The timeout middleware may have already responded; never write twice.
+      if (res.headersSent) {
+        if (err) console.error('report_reports: response already sent, dropping late error:', err.message);
+        return;
+      }
       if (err) return res.status(err.status || 500).send(err.message);
       return res.send(serializeReportResponse(reports));
     };

--- a/backend/fetching/channels/ioda.js
+++ b/backend/fetching/channels/ioda.js
@@ -11,6 +11,7 @@ const {
 const {  recomputeIncidentDurationForGroups } = require('../../api/utils/incidentDuration');
 const Group = require('../../models/group');
 const Report = require('../../models/report');
+const { persistSvgChart } = require('../utils/socialImageStorage');
 const { chromium } = require('playwright');
 const countries = require('i18n-iso-countries');
 require('dotenv').config();
@@ -360,19 +361,27 @@ class IODAChannel extends PollChannel {
             geoScope = entityScope;
         }
 
-        // Fetch and de-duplicate image as svg string
-        if (this.linkedPageCache[linkedPage]) {
-            image = this.linkedPageCache[linkedPage];
-        } else {
-
+        // Extract the chart SVG once per linked page (the Playwright scrape is expensive).
+        let svg = this.linkedPageCache[linkedPage];
+        if (svg === undefined) {
             try {
-                const cleanSVG = await extractCleanSVGFromPage(this.browser, linkedPage, queryType);
-                image = cleanSVG;
-                this.linkedPageCache[linkedPage] = cleanSVG;
+                svg = await extractCleanSVGFromPage(this.browser, linkedPage, queryType);
             } catch (err) {
                 console.error(`Error extracting SVG for URL ${linkedPage}:`, err);
+                svg = null;
             }
+            this.linkedPageCache[linkedPage] = svg;
+        }
 
+        // Persist the SVG to media storage keyed by guid and store the key (not the
+        // raw SVG) on the report, so list/detail responses stay small. Keyed by guid
+        // means a re-fetch of the same outage overwrites the same file in place.
+        if (svg) {
+            try {
+                image = await persistSvgChart({ svg, guid });
+            } catch (err) {
+                console.error(`Error persisting SVG chart for guid ${guid}:`, err);
+            }
         }
 
 
@@ -395,7 +404,7 @@ class IODAChannel extends PollChannel {
                 'started': eventStartedAt,
                 'ended': eventEndedAt,
                 'duration': eventDuration,
-                'image': image, // Store image as svg string
+                'image': image, // media-storage key for the chart SVG (see persistSvgChart)
             }
         });
 

--- a/backend/fetching/hooks/saveToDatabase.js
+++ b/backend/fetching/hooks/saveToDatabase.js
@@ -14,7 +14,12 @@ module.exports = async function saveToDatabase(report, next) {
         
     } catch (error) {
         await deleteSocialAttachments(report?.metadata?.attachments);
-        console.error(`[Fetching-saveToDatabase] Failed - Failed saving reports: ${error.message}.`)
+        if (error.code === 11000) {
+            // Expected dedup: the channel re-fetched a post whose guid is already saved.
+            console.log(`[Fetching-saveToDatabase] Skipped duplicate report (guid already saved): ${report?.guid}.`)
+        } else {
+            console.error(`[Fetching-saveToDatabase] Failed - Failed saving reports: ${error.message}.`)
+        }
     }
     
     await next();

--- a/backend/fetching/utils/socialImageStorage.js
+++ b/backend/fetching/utils/socialImageStorage.js
@@ -147,6 +147,22 @@ async function persistSocialImage({ buffer, sourcePlatform, mimeType }) {
   }
 }
 
+async function persistSvgChart({ svg, guid }) {
+  if (!svg || typeof svg !== 'string' || !guid) return null;
+
+  // Deterministic, filesystem-safe key per event. IODA re-scrapes and overwrites
+  // the chart on every poll while an outage is ongoing; keying by guid means the
+  // re-fetch overwrites the same file in place instead of orphaning a new one.
+  const hash = crypto.createHash('sha1').update(String(guid)).digest('hex');
+  const key = `ioda/charts/${hash}.svg`;
+  const fullPath = resolveMediaPath(key);
+
+  await ensureParentDir(fullPath);
+  await fs.writeFile(fullPath, svg, 'utf-8');
+
+  return key; // stored in place of the inline SVG string
+}
+
 async function deleteMediaByKey(key) {
   const normalizedKey = normalizeKey(key);
   if (!normalizedKey) return;
@@ -172,8 +188,10 @@ async function deleteSocialAttachments(attachments) {
 module.exports = {
   MEDIA_ROUTE_PREFIX,
   buildMediaUrl,
+  deleteMediaByKey,
   deleteSocialAttachments,
   detectImageMimeType,
   getMediaRoot,
   persistSocialImage,
+  persistSvgChart,
 };

--- a/backend/models/report.js
+++ b/backend/models/report.js
@@ -65,6 +65,7 @@ schema.index({ outageStartedAt: 1 });
 schema.index({ outageEndedAt: 1 });
 schema.index({ irrelevant: 1 });
 schema.index({ eventIdentifier: 1 }, { sparse: true }); // sparse index (i.e. only docs with field are indexed)
+schema.index({ isOutageEvent: 1, authoredAt: -1 }); // alerts list: match + sort + limit without in-memory sort
 schema.index({ eventAggKeyBase: 1 }, { sparse: true });
 schema.path('_group').set(function (_group) {
   this._prevGroup = this._group;
@@ -262,11 +263,13 @@ Report.queryReports = function (query, page, callback) {
 
 // Dedup reports based on eventidentifier(if exist), general findPage() does not apply to this 
 Report.queryReportsDeduped = async function (query, page, callback) {
+  if (typeof page === 'function') {
+    callback = page;
+    page = 0;
+  }
+
+  let result;
   try {
-    if (typeof page === 'function') {
-      callback = page;
-      page = 0;
-    }
     if (page === undefined || page === null || Number.isNaN(Number(page))) page = 0;
     if (page < 0) page = 0;
 
@@ -282,13 +285,55 @@ Report.queryReportsDeduped = async function (query, page, callback) {
     const PAGE_LIMIT = 50; // Note: This should be the same as `perPage` in config.js.
 
     const targetUnique = (page + 1) * PAGE_LIMIT;
+    // TODO: when more than half the fetched rows are duplicates, deep pages come
+    // back short while `total` promises more.
     const rawFetchLimit = targetUnique * 2; // fetch extra rows, worst case 2 * page size
 
-    // fetch raw candidates
-    const rawReports = await Report.find(filter)
-      .sort({ authoredAt: -1 })
-      .limit(rawFetchLimit)
-      .lean();
+    // Abort slow queries well before API_REQUEST_TIMEOUT so the HTTP timeout
+    // middleware never responds first and the late result double-sends.
+    const QUERY_TIME_LIMIT_MS = 30000;
+
+    const [rawReports, countRows] = await Promise.all([
+      // fetch raw candidates
+      // IODA reports carry a ~330KB inline SVG chart in metadata.rawAPIResponse.image;
+      // shipping it per list row is what blew past API_REQUEST_TIMEOUT (~43MB/page).
+      // List cards don't render it; the single-report endpoint still returns it.
+      // TODO: move the SVG into media storage (see socialImageStorage) and drop it
+      // from the document entirely.
+      Report.find(filter)
+        .sort({ authoredAt: -1 })
+        .limit(rawFetchLimit)
+        .select({ 'metadata.rawAPIResponse.image': 0 })
+        .maxTimeMS(QUERY_TIME_LIMIT_MS)
+        .lean(),
+      // Deduped total: identified reports count once per distinct eventIdentifier;
+      // reports without one (missing, null, or '') share the null bucket and count
+      // per-doc, matching the `!key` handling in the dedup loop below.
+      Report.aggregate([
+        { $match: filter },
+        {
+          $group: {
+            _id: {
+              $cond: [
+                { $in: [{ $ifNull: ['$eventIdentifier', null] }, [null, '']] },
+                null,
+                '$eventIdentifier'
+              ]
+            },
+            c: { $sum: 1 }
+          }
+        },
+        {
+          $group: {
+            _id: null,
+            total: { $sum: { $cond: [{ $eq: ['$_id', null] }, '$c', 1] } }
+          }
+        },
+        { $project: { _id: 0, total: 1 } }
+      ]).option({ maxTimeMS: QUERY_TIME_LIMIT_MS })
+    ]);
+
+    const [{ total = 0 } = {}] = countRows;
 
     const seen = new Set();
     const deduped = [];
@@ -309,35 +354,21 @@ Report.queryReportsDeduped = async function (query, page, callback) {
     const start = page * PAGE_LIMIT;
     const end = start + PAGE_LIMIT;
 
-    const pageResults = deduped.slice(start, end);
-
-    const [{ total = 0 } = {}] = await Report.aggregate([
-      { $match: filter },
-      {
-        $group: {
-          _id: {
-            $cond: [
-              {
-                $and: [
-                  { $ne: [{ $type: "$eventIdentifier" }, "missing"] },
-                ]
-              },
-              '$eventIdentifier',
-              '$_id'
-            ]
-          }
-        }
-      },
-      { $count: 'total' }
-    ]);
-
-    callback(null, {
+    result = {
       total,
-      results: pageResults
-    });
-
+      results: deduped.slice(start, end)
+    };
   } catch (err) {
-    callback(err);
+    return callback(err);
+  }
+
+  // Outside the main try/catch: if the callback itself throws (e.g. the response
+  // was already sent by the timeout middleware), it must not re-enter callback(err)
+  // or reject this async function (which would crash the api process).
+  try {
+    callback(null, result);
+  } catch (cbErr) {
+    console.error('queryReportsDeduped: callback threw after results were ready:', cbErr.message);
   }
 };
 

--- a/backend/models/report.js
+++ b/backend/models/report.js
@@ -1,65 +1,81 @@
 // A report is a single post/comment/article or other chunk of data from a source.
 // This class is responsible for executing ReportQuerys.
-const database = require('../database');
+const database = require("../database");
 const mongoose = database.mongoose;
-const AutoIncrement = require('mongoose-sequence')(mongoose);
+const AutoIncrement = require("mongoose-sequence")(mongoose);
 const Schema = mongoose.Schema;
 const SchemaTypes = mongoose.SchemaTypes;
-const SMTCTag = require('./tag');
-const { addPost, removePost } = require('../comments');
-const { strict } = require('assert');
+const SMTCTag = require("./tag");
+const { addPost, removePost } = require("../comments");
+const { strict } = require("assert");
 
 let schema = new Schema({
   authoredAt: { type: Date, index: true },
   fetchedAt: { type: Date, index: true },
   storedAt: { type: Date, index: true },
-  isOutageEvent: {type: Boolean, index: true},
-  isAsnScoped: {type:Boolean, index: true},
-  asn: {type: String},
-  outageStartedAt: { type: Date,},
-  outageEndedAt: { type: Date},
-  geoScope: {type: String},
+  isOutageEvent: { type: Boolean, index: true },
+  isAsnScoped: { type: Boolean, index: true },
+  asn: { type: String },
+  outageStartedAt: { type: Date },
+  outageEndedAt: { type: Date },
+  geoScope: { type: String },
   eventIdentifier: { type: String }, // an identifier derived from asn, geoScope, and outageStartedAt
   eventAggKeyBase: { type: String }, // an aggregation key base, derived from asn and geoScope, combined with dynamic time interval bucket in aggregation layer
   content: { type: String },
   author: { type: String },
-  veracity: { type: String, default: 'Unconfirmed', enum: ['Unconfirmed', 'Confirmed True', 'Confirmed False'], index: true },
+  veracity: {
+    type: String,
+    default: "Unconfirmed",
+    enum: ["Unconfirmed", "Confirmed True", "Confirmed False"],
+    index: true,
+  },
   url: { type: String },
   guid: { type: String, index: true, unique: true },
   metadata: Schema.Types.Mixed,
-  smtcTags: { type: [{ type: SchemaTypes.ObjectId, ref: 'SMTCTag' }], default: [] },
+  smtcTags: {
+    type: [{ type: SchemaTypes.ObjectId, ref: "SMTCTag" }],
+    default: [],
+  },
   hasSMTCTags: { type: Boolean, default: false, required: true, index: true },
   closed: { type: Boolean, default: false, required: true },
   read: { type: Boolean, default: false, required: true, index: true },
-  _sources: [{ type: String, ref: 'Source', index: true }],
+  _sources: [{ type: String, ref: "Source", index: true }],
   _media: { type: [String], index: true },
   _sourceNicknames: [String],
-  _group: { type: SchemaTypes.ObjectId, ref: 'Group', index: true },
-  checkedOutBy: { type: Schema.ObjectId, ref: 'User', index: true },
+  _group: { type: SchemaTypes.ObjectId, ref: "Group", index: true },
+  checkedOutBy: { type: Schema.ObjectId, ref: "User", index: true },
   checkedOutAt: { type: Date, index: true },
-  commentTo: { type: Schema.ObjectId, ref: 'Report', index: true },
+  commentTo: { type: Schema.ObjectId, ref: "Report", index: true },
   notes: { type: String },
   escalated: { type: Boolean, default: false, required: true, index: true },
   content_lang: { type: String },
-  irrelevant: { type: String, default: 'maybe', required: false, enum: ['false', 'true', 'maybe'], index: true },
+  irrelevant: {
+    type: String,
+    default: "maybe",
+    required: false,
+    enum: ["false", "true", "maybe"],
+    index: true,
+  },
   aitags: {
     type: Map,
     of: SchemaTypes.Mixed,
     default: {},
   },
-  aitags_feedback: [{
-    type: Map,
-    of: SchemaTypes.Mixed,
-    default: {},
-  }],
+  aitags_feedback: [
+    {
+      type: Map,
+      of: SchemaTypes.Mixed,
+      default: {},
+    },
+  ],
   aitagnames: { type: [String], default: [] },
-  red_flag: { type: Boolean, default: false, index: true }
+  red_flag: { type: Boolean, default: false, index: true },
 });
 
 // schema.index({ 'metadata.ct_tag': 1 }, { background: true });
 // Add fulltext index to the `content` and `author` field.
 
-schema.index({ author: 'text', content: 'text' });
+schema.index({ author: "text", content: "text" });
 schema.index({ geoScope: 1 });
 schema.index({ outageStartedAt: 1 });
 schema.index({ outageEndedAt: 1 });
@@ -67,43 +83,39 @@ schema.index({ irrelevant: 1 });
 schema.index({ eventIdentifier: 1 }, { sparse: true }); // sparse index (i.e. only docs with field are indexed)
 schema.index({ isOutageEvent: 1, authoredAt: -1 }); // alerts list: match + sort + limit without in-memory sort
 schema.index({ eventAggKeyBase: 1 }, { sparse: true });
-schema.path('_group').set(function (_group) {
+schema.path("_group").set(function (_group) {
   this._prevGroup = this._group;
   return _group;
 });
 
 // sets the indexed hasSMTCTags boolean
-schema.pre('save', function (next) {
+schema.pre("save", function (next) {
   this.hasSMTCTags = this.smtcTags.length > 0;
-  next()
+  next();
 });
 
-schema.pre('save', function (next) {
+schema.pre("save", function (next) {
   if (this.isNew) {
     this._wasNew = true;
     // Set default storedAt.
     if (!this.storedAt) this.storedAt = new Date();
-
   } else {
     // Capture updates before saving report
-    if (this.isModified('_group')) {
+    if (this.isModified("_group")) {
       this._groupWasModified = true;
     }
-
   }
   next();
 });
 
 // Emit information about updates after saving report
-schema.post('save', function () {
-  if (this._wasNew) schema.emit('report:new', { _id: this._id.toString() });
-  if (!this._wasNew) schema.emit('report:updated', this);
+schema.post("save", function () {
+  if (this._wasNew) schema.emit("report:new", { _id: this._id.toString() });
+  if (!this._wasNew) schema.emit("report:updated", this);
   if (this._groupWasModified) {
-    schema.emit('change:group', this._prevGroup, this._group);
+    schema.emit("change:group", this._prevGroup, this._group);
   }
 });
-
-
 
 schema.methods.setReadStatus = function (readStatus) {
   this.read = readStatus;
@@ -133,13 +145,17 @@ schema.methods.addSMTCTag = function (smtcTagId, callback) {
     this.smtcTags.push({ _id: smtcTagId });
     this.read = true;
     // Only send a post to the acquisition API if it is a) not a comment b) a FB post and c) not a group post
-    if (!this.commentTo && this._media[0] === 'facebook' && !this.url.match(/permalink/)) {
+    if (
+      !this.commentTo &&
+      this._media[0] === "facebook" &&
+      !this.url.match(/permalink/)
+    ) {
       SMTCTag.findById(smtcTagId, (err, tag) => {
         if (err) {
           console.error(err);
         }
         if (tag.isCommentTag) {
-          addPost(this.url, callback)
+          addPost(this.url, callback);
         } else {
           callback();
         }
@@ -148,7 +164,7 @@ schema.methods.addSMTCTag = function (smtcTagId, callback) {
     }
   }
   callback();
-}
+};
 
 schema.methods.removeSMTCTag = function (smtcTagId, callback) {
   // TODO: Use Functional Programming
@@ -160,17 +176,17 @@ schema.methods.removeSMTCTag = function (smtcTagId, callback) {
       if (smtcTagId === tag.toString()) {
         fndIndex = index;
       }
-    })
+    });
     if (fndIndex !== -1) {
       this.smtcTags.splice(fndIndex, 1);
 
-      if (!this.commentTo && this._media[0] === 'facebook') {
+      if (!this.commentTo && this._media[0] === "facebook") {
         SMTCTag.findById(smtcTagId, (err, tag) => {
           if (err) {
             console.error(err);
           }
           if (tag.isCommentTag) {
-            removePost(this.url, callback)
+            removePost(this.url, callback);
           } else {
             callback();
           }
@@ -180,14 +196,13 @@ schema.methods.removeSMTCTag = function (smtcTagId, callback) {
     }
   }
   callback();
-}
+};
 
 schema.methods.clearSMTCTags = function (callback) {
-
   const cb = () => {
     this.smtcTags = [];
     callback();
-  }
+  };
 
   if (!this.commentTo) {
     let remaining = this.smtcTags.length;
@@ -205,11 +220,11 @@ schema.methods.clearSMTCTags = function (callback) {
     return;
   }
   cb();
-}
+};
 // schema.plugin(AutoIncrement, { inc_field: 'reportId' });
-const Report = mongoose.model('Report', schema);
+const Report = mongoose.model("Report", schema);
 
-SMTCTag.schema.on('tag:removed', function (id) {
+SMTCTag.schema.on("tag:removed", function (id) {
   Report.find({ smtcTags: id }, function (err, reports) {
     if (err) {
       console.error(err);
@@ -217,20 +232,20 @@ SMTCTag.schema.on('tag:removed', function (id) {
     reports.forEach(function (report) {
       report.removeSMTCTag(id, () => {
         report.save();
-      })
+      });
     });
   });
-})
-
+});
 
 // queryReports reports based on passed query data
 Report.queryReports = function (query, page, callback) {
-  if (typeof query === 'function') return Report.findPage(query);
-  if (typeof page === 'function') {
+  if (typeof query === "function") return Report.findPage(query);
+  if (typeof page === "function") {
     callback = page;
     page = 0;
   }
-  if (page === undefined || page === null || Number.isNaN(Number(page))) page = 0;
+  if (page === undefined || page === null || Number.isNaN(Number(page)))
+    page = 0;
   if (page < 0) page = 0;
 
   const filter = query.toMongooseFilter();
@@ -238,11 +253,11 @@ Report.queryReports = function (query, page, callback) {
   // Re-set search timestamp
   query.since = new Date();
 
-  if (query.escalated === 'escalated') filter.escalated = true;
-  if (query.escalated === 'unescalated') filter.escalated = false;
-  if (query.veracity === 'confirmed true') filter.veracity = 'Confirmed True';
-  if (query.veracity === 'confirmed false') filter.veracity = 'Confirmed False';
-  if (query.veracity === 'unconfirmed') filter.veracity = 'Unconfirmed';
+  if (query.escalated === "escalated") filter.escalated = true;
+  if (query.escalated === "unescalated") filter.escalated = false;
+  if (query.veracity === "confirmed true") filter.veracity = "Confirmed True";
+  if (query.veracity === "confirmed false") filter.veracity = "Confirmed False";
+  if (query.veracity === "unconfirmed") filter.veracity = "Unconfirmed";
 
   // console.log(JSON.stringify(filter))
 
@@ -256,32 +271,33 @@ Report.queryReports = function (query, page, callback) {
   // }
   // delete query.keywords
 
-
   Report.findSortedPage(filter, page, callback);
 };
 
-
-// Dedup reports based on eventidentifier(if exist), general findPage() does not apply to this 
+// Dedup reports based on eventidentifier(if exist), general findPage() does not apply to this
 Report.queryReportsDeduped = async function (query, page, callback) {
-  if (typeof page === 'function') {
+  if (typeof page === "function") {
     callback = page;
     page = 0;
   }
 
   let result;
   try {
-    if (page === undefined || page === null || Number.isNaN(Number(page))) page = 0;
+    if (page === undefined || page === null || Number.isNaN(Number(page)))
+      page = 0;
     if (page < 0) page = 0;
 
     const filter = query.toMongooseFilter();
 
     // same extra filters as queryReports
-    if (query.escalated === 'escalated') filter.escalated = true;
-    if (query.escalated === 'unescalated') filter.escalated = false;
-    if (query.veracity === 'confirmed true') filter.veracity = 'Confirmed True';
-    if (query.veracity === 'confirmed false') filter.veracity = 'Confirmed False';
-    if (query.veracity === 'unconfirmed') filter.veracity = 'Unconfirmed';
+    if (query.escalated === "escalated") filter.escalated = true;
+    if (query.escalated === "unescalated") filter.escalated = false;
+    if (query.veracity === "confirmed true") filter.veracity = "Confirmed True";
+    if (query.veracity === "confirmed false")
+      filter.veracity = "Confirmed False";
+    if (query.veracity === "unconfirmed") filter.veracity = "Unconfirmed";
 
+    // TODO: can i import this from perPage?
     const PAGE_LIMIT = 50; // Note: This should be the same as `perPage` in config.js.
 
     const targetUnique = (page + 1) * PAGE_LIMIT;
@@ -295,15 +311,11 @@ Report.queryReportsDeduped = async function (query, page, callback) {
 
     const [rawReports, countRows] = await Promise.all([
       // fetch raw candidates
-      // IODA reports carry a ~330KB inline SVG chart in metadata.rawAPIResponse.image;
-      // shipping it per list row is what blew past API_REQUEST_TIMEOUT (~43MB/page).
-      // List cards don't render it; the single-report endpoint still returns it.
-      // TODO: move the SVG into media storage (see socialImageStorage) and drop it
-      // from the document entirely.
+      // IODA chart SVGs now live in media storage (metadata.rawAPIResponse.image holds
+      // a small key, not the inline SVG), so list rows are cheap to ship in full.
       Report.find(filter)
         .sort({ authoredAt: -1 })
         .limit(rawFetchLimit)
-        .select({ 'metadata.rawAPIResponse.image': 0 })
         .maxTimeMS(QUERY_TIME_LIMIT_MS)
         .lean(),
       // Deduped total: identified reports count once per distinct eventIdentifier;
@@ -315,22 +327,22 @@ Report.queryReportsDeduped = async function (query, page, callback) {
           $group: {
             _id: {
               $cond: [
-                { $in: [{ $ifNull: ['$eventIdentifier', null] }, [null, '']] },
+                { $in: [{ $ifNull: ["$eventIdentifier", null] }, [null, ""]] },
                 null,
-                '$eventIdentifier'
-              ]
+                "$eventIdentifier",
+              ],
             },
-            c: { $sum: 1 }
-          }
+            c: { $sum: 1 },
+          },
         },
         {
           $group: {
             _id: null,
-            total: { $sum: { $cond: [{ $eq: ['$_id', null] }, '$c', 1] } }
-          }
+            total: { $sum: { $cond: [{ $eq: ["$_id", null] }, "$c", 1] } },
+          },
         },
-        { $project: { _id: 0, total: 1 } }
-      ]).option({ maxTimeMS: QUERY_TIME_LIMIT_MS })
+        { $project: { _id: 0, total: 1 } },
+      ]).option({ maxTimeMS: QUERY_TIME_LIMIT_MS }),
     ]);
 
     const [{ total = 0 } = {}] = countRows;
@@ -356,7 +368,7 @@ Report.queryReportsDeduped = async function (query, page, callback) {
 
     result = {
       total,
-      results: deduped.slice(start, end)
+      results: deduped.slice(start, end),
     };
   } catch (err) {
     return callback(err);
@@ -368,15 +380,23 @@ Report.queryReportsDeduped = async function (query, page, callback) {
   try {
     callback(null, result);
   } catch (cbErr) {
-    console.error('queryReportsDeduped: callback threw after results were ready:', cbErr.message);
+    console.error(
+      "queryReportsDeduped: callback threw after results were ready:",
+      cbErr.message,
+    );
   }
 };
 
 Report.findSortedPage = function (filter, page, callback) {
-  Report.findPage(filter, page, { sort: '-authoredAt' }, function (err, reports) {
-    if (err) return callback(err);
-    callback(null, reports);
-  });
+  Report.findPage(
+    filter,
+    page,
+    { sort: "-authoredAt" },
+    function (err, reports) {
+      if (err) return callback(err);
+      callback(null, reports);
+    },
+  );
 };
 
 module.exports = Report;

--- a/docs/claude-plans/fix-reports-timeout-double-send.md
+++ b/docs/claude-plans/fix-reports-timeout-double-send.md
@@ -1,0 +1,133 @@
+# Fix: reports query timeout → ERR_HTTP_HEADERS_SENT double-send (+ slow dedup query, noisy E11000 log)
+
+## Why this is happening now
+
+Nothing on the current branch caused it. `queryReportsDeduped` and its bugs (double-callback, per-document `$group` count) landed in `4f66ac4d` on 2026-03-19; the branch's backend commits (mastodon, telegram, media serving) don't touch the query path. The failure is load/data-dependent:
+
+- Every reports/alerts list load re-runs the count aggregate, which hashes **every matched document**. The reports collection grows continuously (IODA/Cloudflare/social fetchers), so this query gets slower every week — it has now started crossing the 60s `API_REQUEST_TIMEOUT` line.
+- It's worst exactly when fetching is busy writing (the E11000 in the same log window shows the fetcher mid-save), since the aggregate competes with insert load.
+- Once the 60s line is crossed, the latent double-callback bug turns a plain timeout into the `ERR_HTTP_HEADERS_SENT` crash log. Expect it to recur with increasing frequency until the perf fix lands.
+
+## Context
+
+Two recurring backend errors:
+
+```
+[Fetching-saveToDatabase] Failed - Failed saving reports: E11000 duplicate key error ... index: guid_1 ...
+Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client
+    at handler (backend/api/controllers/reportController.js:107)
+    at Report.queryReportsDeduped (backend/models/report.js:340)
+```
+
+These are unrelated to the earlier assign-user frontend crash. The chain behind the headers-sent error:
+
+1. `GET /api/report` (most reports/alerts list loads — `shouldDedupByEventIdentifier` returns true whenever there's no `entityLevel`/`groupId` filter) runs `Report.queryReportsDeduped` ([backend/models/report.js:264-342](backend/models/report.js#L264)).
+2. That function runs a `find` (sorted by `authoredAt`, limited) **then sequentially** a count aggregate whose `$group` builds a hash entry per matched document — slow on a large collection. With the current indexes the alerts filter (`{isOutageEvent: true, irrelevant: {$ne:'true'}}` + sort `authoredAt: -1`) forces either an in-memory sort of all outage docs or a residual walk of the `authoredAt` index. The request exceeded `API_REQUEST_TIMEOUT=60000`.
+3. The timeout middleware ([backend/api.js:117-144](backend/api.js#L117)) sends `res.sendStatus(500)`.
+4. The query later completes → `callback(null, results)` → controller handler calls `res.send` → throws `ERR_HTTP_HEADERS_SENT` → **the `try/catch` in `queryReportsDeduped` catches the callback's own throw and invokes `callback(err)` a second time** → second `res.send` throws again → the logged crash.
+
+The E11000 log is separate and mostly benign: a channel re-fetched a post whose `guid` already exists; the unique index correctly rejects it and `saveToDatabase` ([backend/fetching/hooks/saveToDatabase.js](backend/fetching/hooks/saveToDatabase.js)) cleans up the duplicate's freshly-uploaded attachments (keys are `crypto.randomBytes`-derived, so no collision with the original's files). It just logs expected dedup as a scary error.
+
+User chose scope: **error handling + perf**.
+
+## Changes
+
+### 1. `backend/models/report.js` — `queryReportsDeduped` (lines ~264-342)
+
+**a. Single-invoke callback.** Restructure so the callback can never fire twice: do all async work inside `try`, capture the result, and call `callback` exactly once _after_ the try/catch (`catch` does `return callback(err)`). With `Promise.all` (below), the guard wraps the combined await — not each promise.
+
+**b. Parallelize + bound the two DB ops.**
+
+- `Report.find(filter).sort({ authoredAt: -1 }).limit(rawFetchLimit).maxTimeMS(30000).lean()`
+- count aggregate with `.option({ maxTimeMS: 30000 })`
+- run both via `Promise.all`. (APIs verified on installed mongoose 5.13.23: `Query#maxTimeMS`, `Aggregate#option`.) A query that's still slow now fails at ~30s with `MaxTimeMSExpired` → one clean 500, no race with the 60s middleware.
+
+**c. Fix + cheapen the count aggregate.** The current `$cond` on `$type ne 'missing'` collapses all `eventIdentifier: null` docs into one group (and `''` docs into another) while the in-JS dedup at line 299 keeps every `!key` doc — so `total` undercounts vs. results, and the `'$_id'` fallback gives the `$group` one hash entry per doc. Replace with a two-stage group matching the JS `!key` semantics exactly, bounded by (#distinct events + 1):
+
+```js
+const [{ total = 0 } = {}] = await Report.aggregate([
+  { $match: filter },
+  {
+    $group: {
+      _id: {
+        $cond: [
+          { $in: [{ $ifNull: ["$eventIdentifier", null] }, [null, ""]] },
+          null,
+          "$eventIdentifier",
+        ],
+      },
+      c: { $sum: 1 },
+    },
+  },
+  {
+    $group: {
+      _id: null,
+      total: { $sum: { $cond: [{ $eq: ["$_id", null] }, "$c", 1] } },
+    },
+  },
+  { $project: { _id: 0, total: 1 } },
+]).option({ maxTimeMS: 30000 });
+```
+
+**d. Compound index** near the existing `schema.index(...)` block (~line 67):
+
+```js
+schema.index({ isOutageEvent: 1, authoredAt: -1 });
+```
+
+Serves the common alerts-view match + sort + limit directly (`irrelevant: {$ne:'true'}` stays a cheap residual filter; deliberately NOT in the index — `$ne` on a prefix key forfeits the index-provided sort). Indexes are ensured via `install.js` → `Report.ensureIndexes` (runs on `postinstall`; can also be triggered manually).
+
+Leave a `// TODO` on the `rawFetchLimit = targetUnique * 2` heuristic: when >half the fetched rows are duplicates, deep pages come back short while `total` promises more. Out of scope here.
+
+### 2. `backend/api/controllers/reportController.js` — `handler` (lines ~106-109)
+
+Defense in depth — never write after the timeout middleware has responded:
+
+```js
+const handler = (err, reports) => {
+  if (res.headersSent) {
+    if (err)
+      console.error(
+        "report_reports: response already sent, dropping late error:",
+        err.message,
+      );
+    return;
+  }
+  if (err) return res.status(err.status || 500).send(err.message);
+  return res.send(serializeReportResponse(reports));
+};
+```
+
+### 3. `backend/fetching/hooks/saveToDatabase.js` — quiet expected duplicates
+
+In the `catch`, branch on `error.code === 11000`: keep the attachment cleanup, but log it as expected dedup (e.g., `console.log('[Fetching-saveToDatabase] Skipped duplicate report (guid already saved): ...')`) instead of the `Failed saving reports` error. All other errors keep the current error log.
+
+## Files to modify
+
+- [backend/models/report.js](backend/models/report.js) — single-invoke callback, `Promise.all` + `maxTimeMS`, replacement count pipeline, compound index.
+- [backend/api/controllers/reportController.js](backend/api/controllers/reportController.js) — `res.headersSent` guard in `handler`.
+- [backend/fetching/hooks/saveToDatabase.js](backend/fetching/hooks/saveToDatabase.js) — downgrade E11000 log.
+
+No frontend or API-shape changes (`{ total, results }` unchanged).
+
+## Verification
+
+- Rebuild indexes: `node install.js` (or restart with postinstall) — confirm `isOutageEvent_1_authoredAt_-1` exists via `db.reports.getIndexes()`.
+- `npm run dev`, load `https://localhost:8000/` reports and alerts views — lists load, pagination totals sane, and noticeably faster on the alerts view; check Mongo with `.explain()` on the find shape if needed (expect IXSCAN on the new compound index).
+- Reproduce the timeout path: temporarily set `API_REQUEST_TIMEOUT=1` in `.env`, hit `/api/report` — expect a single 500 and **no** `ERR_HTTP_HEADERS_SENT` in the backend log; restore the value after.
+- Count-vs-results consistency: with reports lacking `eventIdentifier` in the DB (normal social reports), confirm `total` ≥ number of listed unique rows and page count matches what's fetchable.
+- Let fetching run across a refetch window: duplicate guids now log as a one-line skip, not a `Failed` error; attachments for duplicates still cleaned (no orphan files accumulating under the media root).
+
+---
+
+## Addendum (implemented): the real payload culprit + follow-up
+
+Verification against the dev Atlas cluster showed the index and count pipeline were never the bottleneck (find ids: 150ms, count: 56ms). The alerts list was timing out because **every IODA report stores a ~330KB scraped SVG chart inline at `metadata.rawAPIResponse.image`** ([backend/fetching/channels/ioda.js:398](../../backend/fetching/channels/ioda.js#L398)) — one page of the dedup query fetched 100 full docs ≈ 43MB, ~7 minutes of transfer. `maxTimeMS` can't help; it bounds server execution, not result transfer.
+
+**Implemented now:** the dedup list query excludes that field (`.select({ 'metadata.rawAPIResponse.image': 0 })` in `queryReportsDeduped`). Alerts page 0 went from a 60s timeout to ~2s / 83KB. The single-report endpoint still returns the image, so the report detail view keeps its chart. The projection was deliberately NOT applied to `findSortedPage`/`queryReports` because the `groupId` (incident detail) path renders full `SocialMediaPost` cards that need the chart.
+
+**Known gaps / follow-up (separate branch):**
+
+- Move the SVG out of the document into media storage (reuse `backend/fetching/utils/socialImageStorage.js` + `serializeReport` URL emission), update `IodaEvent`/`TrafficEvent` to `<img src={url}>`, and migrate the ~1000 existing IODA reports. That restores charts in any list-driven UI (e.g., the feature branch's alert table/compare modal, which read from the list response and currently won't have the inline SVG) and shrinks the collection.
+- `hideDuplicateASNs=false` forces the non-dedup path (`queryReports`), which still fetches full docs — slow again with many IODA reports until the media-storage move lands.
+- Verified behavior of the error-handling fix: `aggie-api` survived repeated 60s timeouts without the previous crash-loop (it used to die on the unhandled `ERR_HTTP_HEADERS_SENT` and get respawned by process-manager).

--- a/docs/claude-plans/ioda-v2-chart-investigation.md
+++ b/docs/claude-plans/ioda-v2-chart-investigation.md
@@ -1,0 +1,58 @@
+# IODA v2 API — can we get a URL to the SVG alert/event charts?
+
+> **Investigation only — no code change.** Conclusion documented for future reference.
+
+## Context
+
+Aggie currently obtains the IODA outage chart by launching a headless Playwright/Chromium browser on **every** fetch, navigating to the IODA dashboard page, waiting for Highcharts to render, and scraping the `svg.highcharts-root` element out of the DOM ([iodaUtils.js:16-46](../../backend/fetching/utils/iodaUtils.js#L16-L46), called from [ioda.js:364-385](../../backend/fetching/channels/ioda.js#L364-L385)). That scrape is heavy and fragile (it depends on the dashboard's DOM, a `data-highcharts-chart` index hack, and a 30s render wait). The question: **does the IODA v2 API expose a URL/endpoint that returns the chart SVG directly, so we could skip the browser scrape?**
+
+## Conclusion
+
+**No.** The IODA v2 API has **no chart-image endpoint** — nothing returns a rendered SVG/PNG, and nothing returns a URL to one.
+
+Evidence:
+- Enumerated every controller in [InetIntel/ioda-api](https://github.com/InetIntel/ioda-api): `Api`, `Datasources`, `Entities`, `Outages`, `Signals`, `Topo`, `SymUrl`. A grep across all of them for `svg|png|image|chart|render|highchart` returned **nothing**.
+- Cross-checked the [CAIDA ioda-api API Specification](https://github.com/CAIDA/ioda-api/wiki/API-Specification) — no image/chart endpoint listed.
+- The charts on the IODA dashboard are rendered **client-side by Highcharts** from raw time-series JSON. That is precisely why Aggie has to scrape the rendered DOM — there is no server-rendered image to fetch.
+
+## What the API *does* expose (verified live, HTTP 200)
+
+The data behind the dashboard chart is available directly:
+
+```
+GET https://api.ioda.inetintel.cc.gatech.edu/v2/signals/raw/{entityType}/{entityCode}
+      ?from={unixSeconds}&until={unixSeconds}&datasource={bgp|merit-nt|ping-slash24|gtr|...}&maxPoints={n}
+
+→ { type: "signals", metadata, requestParameters, error, perf,
+    data: [ [ { entityType, entityCode, datasource, subtype, from, until,
+                step, nativeStep, values: [ ...numeric measurements... ] } ] ] }
+```
+
+This is the same `/signals/raw/...` time-series the dashboard's Highcharts consumes. So: **no chart URL, but the chart data is directly available.**
+
+### Endpoints relevant to Aggie (v2, `https://api.ioda.inetintel.cc.gatech.edu/v2/`)
+
+| Endpoint | Returns | Used by Aggie today |
+|---|---|---|
+| `entities/query` (`?entityType=&relatedTo=`) | entity code→name metadata | yes ([ioda.js:39](../../backend/fetching/channels/ioda.js#L39)) |
+| `outages/events` (`?entityType=&relatedTo=&from=&until=`) | outage event list | yes ([ioda.js:109](../../backend/fetching/channels/ioda.js#L109)) |
+| `signals/raw/{entityType}/{entityCode}` (`?from=&until=&datasource=&maxPoints=`) | chart time-series JSON | **no — this is the data we'd need to render charts ourselves** |
+| `outages/alerts/{...}`, `outages/summary/{...}`, `datasources/{...}`, `topo/{...}` | alerts / scores / datasource meta / topojson | no |
+
+## Decision
+
+**Keep the current Playwright scrape.** Findings documented only — no migration. The scrape produces a pixel-perfect copy of the real dashboard chart, and the recently-built media-storage SVG path ([move-ioda-svg-to-media-storage.md](./move-ioda-svg-to-media-storage.md)) stays as-is.
+
+## Noted for the future (not in scope now)
+
+If the Playwright scrape ever becomes a maintenance burden, the `signals/raw` endpoint unlocks two browser-free alternatives:
+
+1. **Frontend render** — fetch `signals/raw` in the channel, store the compact time-series JSON on the report, render the chart in a React component. Removes Playwright, jsdom, DOMPurify, **and** the media-storage SVG machinery. Cost: must build/maintain a chart component that approximates the IODA Highcharts chart (multiple datasources, axis normalization, styling).
+2. **Server-side SVG render** — fetch `signals/raw`, render an SVG on the backend (Highcharts export server or a lightweight renderer), keep the existing `/media` storage + `<img>` path. Removes the full headless browser but keeps server-side rendering. Same chart-reproduction cost as #1.
+
+The trade-off either way: the scrape gets a pixel-perfect chart for free; rendering ourselves means reproducing IODA's chart config and maintaining it as their dashboard evolves.
+
+## Verification (done during investigation)
+
+- Live probe: `GET /v2/signals/raw/country/US?from=…&until=…&maxPoints=20` → **HTTP 200** with `data[]` time-series (datasources: GTR, BGP, ping, Mozilla, transit), `step`/`nativeStep`/`values`.
+- Controller enumeration + grep confirming no image/chart endpoint exists.

--- a/docs/claude-plans/move-ioda-svg-to-media-storage.md
+++ b/docs/claude-plans/move-ioda-svg-to-media-storage.md
@@ -1,0 +1,147 @@
+# Follow-up: move IODA chart SVGs out of MongoDB into file storage
+
+> **Status: implemented & verified** on branch `fix/ioda-svg-media-storage` (off `fix/reports-timeout-double-send`). Migration run on dev moved **916** reports; alerts list dropped from ~43MB/60s-timeout to ~90KB/0.3s. Code snippets below match the committed implementation.
+
+## Branch strategy
+
+New branch `fix/ioda-svg-media-storage`, cut **from the current `fix/reports-timeout-double-send` branch** (not from `staging`), so it carries the timeout/double-send fixes already made and is self-contained. Because those fixes come along, the list-projection exclusion line exists on this base, so **step #6 (remove the band-aid) stays in scope here** rather than being deferred. Claude makes the edits; the user commits (no commits by Claude).
+
+## Context
+
+The timeout fix stopped the alerts list from shipping a ~330KB inline SVG chart per IODA report by excluding `metadata.rawAPIResponse.image` from the list query. That was a band-aid: the SVG still bloats every IODA document (~440KB avg vs ~1KB for other reports), and excluding it means the feature branch's alert table / compare modal can't show charts from list data. This follow-up removes the SVG from the documents entirely, storing each chart as a file served over `/media` (reusing the existing social-image storage infra) and keeping only a small key in the document.
+
+### Key finding — how IODA writes to Mongo (answers "are they overwritten every fetch?")
+
+IODA is the **one source that does not just reject duplicates** — it overwrites. Every other source goes postToReport → `Report.create()`, and a re-fetch of an existing `guid` is rejected by the unique index (the E11000 we quieted). IODA instead runs its **own** dedup in the channel ([ioda.js:176-218](../../backend/fetching/channels/ioda.js#L176)):
+
+- New event → `enqueue` → normal hooks pipeline → `Report.create` (new doc).
+- **Existing event (matched by `guid`)** → `Report.findOne` → overwrites `existingReport.metadata.rawAPIResponse = formattedEvent.raw` (re-scraped SVG included) → `save()` — **every fetch interval**.
+
+So an IODA report's SVG is **re-scraped and re-written on every poll** (the outage may still be ongoing, so the chart legitimately changes). This is the design constraint: the new storage path must be **stable-keyed per `guid`** so the update overwrites the same file in place — otherwise we'd orphan a ~330KB file on disk every fetch cycle.
+
+`guid` is stable per event: `platformID = `${queryType}-${event.start}-${event.location}-${event.datasource}`` ([ioda.js:322](../../backend/fetching/channels/ioda.js#L322)), copied to `report.guid` in [postToReport.js:37](../../backend/fetching/hooks/postToReport.js#L37).
+
+## Design
+
+### 1. New storage helper — `persistSvgChart` in [socialImageStorage.js](../../backend/fetching/utils/socialImageStorage.js)
+
+Existing `persistSocialImage` can't be reused as-is: it detects mime from binary magic bytes, makes a `sips` thumbnail, and uses a **random** token (we need a deterministic key). Add a small sibling (`crypto` is already required at the top of the file):
+
+```js
+async function persistSvgChart({ svg, guid }) {
+  if (!svg || typeof svg !== 'string' || !guid) return null;
+
+  // Deterministic, filesystem-safe key per event. IODA re-scrapes and overwrites
+  // the chart on every poll while an outage is ongoing; keying by guid means the
+  // re-fetch overwrites the same file in place instead of orphaning a new one.
+  const hash = crypto.createHash('sha1').update(String(guid)).digest('hex');
+  const key = `ioda/charts/${hash}.svg`;
+  const fullPath = resolveMediaPath(key);
+
+  await ensureParentDir(fullPath);
+  await fs.writeFile(fullPath, svg, 'utf-8');
+
+  return key; // stored in place of the inline SVG string
+}
+```
+
+No thumbnail (SVG is vector — scales in an `<img>`). Reuses existing `resolveMediaPath` / `ensureParentDir`. Export it; also export the existing `deleteMediaByKey` (previously unexported) for cleanup.
+
+### 2. Channel integration — single point in [ioda.js](../../backend/fetching/channels/ioda.js) (~line 363)
+
+Keep caching the **extracted SVG string** per linked page (the Playwright scrape is expensive and multiple events can share a `linkedPage`), but persist to storage per-`guid` so each report owns its own chart file. Store the returned **key** (not the SVG) in `raw.image`:
+
+```js
+// Extract the chart SVG once per linked page (the Playwright scrape is expensive).
+let svg = this.linkedPageCache[linkedPage];
+if (svg === undefined) {
+    try {
+        svg = await extractCleanSVGFromPage(this.browser, linkedPage, queryType);
+    } catch (err) {
+        console.error(`Error extracting SVG for URL ${linkedPage}:`, err);
+        svg = null;
+    }
+    this.linkedPageCache[linkedPage] = svg;
+}
+
+// Persist the SVG to media storage keyed by guid and store the key (not the
+// raw SVG) on the report, so list/detail responses stay small. Keyed by guid
+// means a re-fetch of the same outage overwrites the same file in place.
+if (svg) {
+    try {
+        image = await persistSvgChart({ svg, guid });
+    } catch (err) {
+        console.error(`Error persisting SVG chart for guid ${guid}:`, err);
+    }
+}
+```
+
+(`guid` is already in scope — the `platformID`. The cache stores the SVG string keyed by `linkedPage`; a cached `null` means a failed scrape and is not retried in the same run.)
+
+This one change covers **both** paths because both read `formattedEvent.raw`:
+- New report → `raw.image` (key) flows through postToReport → `metadata.rawAPIResponse.image`.
+- Update path ([ioda.js:197](../../backend/fetching/channels/ioda.js#L197)) → assigns the same `formattedEvent.raw` (key) → same stable file overwritten.
+
+### 3. Serialize a URL — `serializeReport` in [reportController.js](../../backend/api/controllers/reportController.js#L44)
+
+`metadata.rawAPIResponse.image` now holds a key. Emit a sibling URL the frontend can use (guard so a legacy inline SVG — starts with `<` — still passes through during rollout):
+
+```js
+const rawAPIResponse = plainReport?.metadata?.rawAPIResponse;
+const chartKey = rawAPIResponse?.image;
+const rawAPIResponseWithUrl =
+  chartKey && typeof chartKey === 'string' && !chartKey.trimStart().startsWith('<')
+    ? { ...rawAPIResponse, imageUrl: buildMediaUrl(chartKey) }
+    : rawAPIResponse;
+```
+
+Fold it into the returned metadata alongside the existing `attachments` handling, only when present: `...(rawAPIResponse ? { rawAPIResponse: rawAPIResponseWithUrl } : {})`.
+
+### 4. Frontend — render via `<img>`
+
+- [IodaEvent.tsx](../../src/components/SocialMediaPost/IodaEvent.tsx): replace the `dangerouslySetInnerHTML` SVG-string block with `<img src={rawData?.imageUrl} alt='outage chart' className='w-full h-auto' />` (drops the width/height string-replace hack — CSS handles sizing; also dropped the now-unused `isObject`/`isString` lodash import).
+- [TrafficEvent.tsx](../../src/components/SocialMediaPost/TrafficEvent.tsx): already `<img src={rawData?.image}>` — point it at `rawData?.imageUrl`.
+- [src/api/reports/types.ts](../../src/api/reports/types.ts): add `image?: string` and `imageUrl?: string` to `RawApiResponse` (it already has an index signature, so this is for clarity).
+
+### 5. One-off migration for the existing IODA reports
+
+[scripts/migrate-ioda-svg-to-storage.js](../../scripts/migrate-ioda-svg-to-storage.js), connecting via `backend/database`. Idempotent — the cursor filter (`'metadata.rawAPIResponse.image': /^\s*</`) only matches docs whose `image` is still an inline SVG, and each doc is re-checked with an `isInlineSvg` guard before writing. The script tallies `migrated`/`skipped`/`failed` and logs progress every 100. Core loop:
+
+```js
+const key = await persistSvgChart({ svg, guid: report.guid });
+report.metadata.rawAPIResponse.image = key;
+report.markModified('metadata');
+await report.save();
+```
+
+Run with `node scripts/migrate-ioda-svg-to-storage.js`. Re-runnable (migrated docs hold a key, not `<…>`, so the filter skips them). **Verified on dev: 916 migrated, second run = 0.**
+
+### 6. Remove the band-aid (after migration)
+
+Once the channel writes keys and the migration has run, delete the `.select({ 'metadata.rawAPIResponse.image': 0 })` exclusion in `queryReportsDeduped` ([report.js](../../backend/models/report.js)). Documents are now tiny, so the key ships in list responses and the browser lazy-loads only visible charts via `<img>` — this is what restores charts in the feature branch's table/compare views.
+
+### Optional / lower priority — delete chart on report deletion
+
+Charts are bounded (one stable file per outage event, overwritten not appended), so the leak is small. If a report-delete path exists, call `deleteMediaByKey(report.metadata.rawAPIResponse.image)` there. Note and defer unless there's an existing cleanup hook to extend.
+
+## Files to modify
+
+- [backend/fetching/utils/socialImageStorage.js](../../backend/fetching/utils/socialImageStorage.js) — add + export `persistSvgChart`; also export `deleteMediaByKey`.
+- [backend/fetching/channels/ioda.js](../../backend/fetching/channels/ioda.js) — persist SVG, store key in `raw.image`; cache the SVG string per linked page.
+- [backend/api/controllers/reportController.js](../../backend/api/controllers/reportController.js) — emit `rawAPIResponse.imageUrl` in `serializeReport`.
+- [src/components/SocialMediaPost/IodaEvent.tsx](../../src/components/SocialMediaPost/IodaEvent.tsx) + [TrafficEvent.tsx](../../src/components/SocialMediaPost/TrafficEvent.tsx) — `<img src={imageUrl}>`.
+- [src/api/reports/types.ts](../../src/api/reports/types.ts) — add `image`/`imageUrl` to `RawApiResponse`.
+- [backend/models/report.js](../../backend/models/report.js) — remove list projection exclusion (last, after migration).
+- New: [scripts/migrate-ioda-svg-to-storage.js](../../scripts/migrate-ioda-svg-to-storage.js) — one-off backfill.
+
+## Verification
+
+Done (verified on dev):
+- **Migration:** **916 migrated, 0 skipped, 0 failed**; 917 files under `public/media/ioda/charts/`; **second run = 0** (filter skips migrated docs).
+- **List size:** with the projection exclusion removed, `GET /api/report?alerts=true&page=0` returned **~90KB in 0.3s** (was 43MB/60s), each IODA result carrying the key + resolved `imageUrl`.
+- **Media route:** `GET /media/ioda/charts/<sha1>.svg` → 200, `image/svg+xml`.
+- **Typecheck:** `npx tsc --noEmit` clean.
+
+Still to confirm:
+- **Live fetch path:** watch the next IODA poll — a brand-new report's `metadata.rawAPIResponse.image` should be a key like `ioda/charts/<sha1>.svg` with the file on disk, and repeated polls of the same ongoing outage should **not** grow the file count under `ioda/charts/` (same key overwritten in place).
+- **Frontend (visual):** report detail shows the chart, and the feature branch's alert table / compare modal render charts (lazy-loaded via `<img>`).

--- a/docs/claude-plans/move-ioda-svg-to-media-storage.md
+++ b/docs/claude-plans/move-ioda-svg-to-media-storage.md
@@ -120,6 +120,41 @@ Run with `node scripts/migrate-ioda-svg-to-storage.js`. Re-runnable (migrated do
 
 Once the channel writes keys and the migration has run, delete the `.select({ 'metadata.rawAPIResponse.image': 0 })` exclusion in `queryReportsDeduped` ([report.js](../../backend/models/report.js)). Documents are now tiny, so the key ships in list responses and the browser lazy-loads only visible charts via `<img>` — this is what restores charts in the feature branch's table/compare views.
 
+### 7. Fix Cloudflare chart regression (found after merge)
+
+The `imageUrl` work in §3–§4 is source-agnostic, but Cloudflare's `metadata.rawAPIResponse.image` is **not** an inline SVG — it's a remote Radar chart **URL** (`'image': image, // Store image as https url`, [cloudflare.js:312](../../backend/fetching/channels/cloudflare.js#L312), built from `API_LINKED_PAGE_URLS.CLOUDFLARE.IMAGE_ROUTE`). Two source-agnostic changes on this branch broke it:
+
+- [TrafficEvent.tsx:20](../../src/components/SocialMediaPost/TrafficEvent.tsx#L20) switched the Cloudflare chart from `rawData?.image` (the real URL) to `rawData?.imageUrl`.
+- `serializeReport` ([reportController.js:64-69](../../backend/api/controllers/reportController.js#L64)) only guards the inline-SVG shape (`startsWith('<')`); a Cloudflare URL falls through to `buildMediaUrl(image)`, which treats it as a relative media key and mangles it:
+
+```
+https://radar.cloudflare.com/.../png?image=true&...  ->  /media/https:/radar.cloudflare.com/.../png?image=true&...   (404)
+```
+
+So Cloudflare charts that worked pre-branch now 404 against the `/media` static mount.
+
+**Fix** — make `serializeReport` handle the three shapes of `image`, not two:
+
+```js
+const rawAPIResponse = plainReport?.metadata?.rawAPIResponse;
+const chartImage = rawAPIResponse?.image;
+let imageUrl;
+if (typeof chartImage === 'string') {
+  const trimmed = chartImage.trimStart();
+  if (trimmed.startsWith('<')) {
+    imageUrl = undefined;                 // legacy inline SVG (pre-migration IODA) — leave as-is
+  } else if (/^https?:\/\//i.test(trimmed)) {
+    imageUrl = chartImage;                // absolute remote URL (Cloudflare Radar) — pass through unchanged
+  } else {
+    imageUrl = buildMediaUrl(chartImage); // relative media key (post-migration IODA) — resolve to /media/...
+  }
+}
+const rawAPIResponseWithUrl =
+  imageUrl != null ? { ...rawAPIResponse, imageUrl } : rawAPIResponse;
+```
+
+Optional defense-in-depth: `TrafficEvent.tsx` can fall back to `src={rawData?.imageUrl ?? rawData?.image}` (the original `image` URL still survives in the serialized payload). No change needed in `cloudflare.js` — it has no inline SVG to move.
+
 ### Optional / lower priority — delete chart on report deletion
 
 Charts are bounded (one stable file per outage event, overwritten not appended), so the leak is small. If a report-delete path exists, call `deleteMediaByKey(report.metadata.rawAPIResponse.image)` there. Note and defer unless there's an existing cleanup hook to extend.
@@ -128,7 +163,7 @@ Charts are bounded (one stable file per outage event, overwritten not appended),
 
 - [backend/fetching/utils/socialImageStorage.js](../../backend/fetching/utils/socialImageStorage.js) — add + export `persistSvgChart`; also export `deleteMediaByKey`.
 - [backend/fetching/channels/ioda.js](../../backend/fetching/channels/ioda.js) — persist SVG, store key in `raw.image`; cache the SVG string per linked page.
-- [backend/api/controllers/reportController.js](../../backend/api/controllers/reportController.js) — emit `rawAPIResponse.imageUrl` in `serializeReport`.
+- [backend/api/controllers/reportController.js](../../backend/api/controllers/reportController.js) — emit `rawAPIResponse.imageUrl` in `serializeReport`; the guard must distinguish the three `image` shapes (inline SVG vs absolute URL vs relative key) so Cloudflare's remote URL isn't mangled (§7).
 - [src/components/SocialMediaPost/IodaEvent.tsx](../../src/components/SocialMediaPost/IodaEvent.tsx) + [TrafficEvent.tsx](../../src/components/SocialMediaPost/TrafficEvent.tsx) — `<img src={imageUrl}>`.
 - [src/api/reports/types.ts](../../src/api/reports/types.ts) — add `image`/`imageUrl` to `RawApiResponse`.
 - [backend/models/report.js](../../backend/models/report.js) — remove list projection exclusion (last, after migration).
@@ -145,3 +180,4 @@ Done (verified on dev):
 Still to confirm:
 - **Live fetch path:** watch the next IODA poll — a brand-new report's `metadata.rawAPIResponse.image` should be a key like `ioda/charts/<sha1>.svg` with the file on disk, and repeated polls of the same ongoing outage should **not** grow the file count under `ioda/charts/` (same key overwritten in place).
 - **Frontend (visual):** report detail shows the chart, and the feature branch's alert table / compare modal render charts (lazy-loaded via `<img>`).
+- **Cloudflare chart (§7):** a Cloudflare traffic-anomaly report renders its chart — the `<img src>` resolves to the `radar.cloudflare.com` URL, not a mangled `/media/https:/…` path (404).

--- a/scripts/migrate-ioda-svg-to-storage.js
+++ b/scripts/migrate-ioda-svg-to-storage.js
@@ -1,0 +1,73 @@
+// One-off backfill: move inline IODA chart SVGs out of MongoDB into media storage.
+//
+// Before this change, IODA reports stored the full chart SVG (~330KB) inline at
+// metadata.rawAPIResponse.image, bloating every document. The channel now stores a
+// media-storage key instead. This script converts existing reports: it writes each
+// inline SVG to storage (keyed by guid, same as the channel) and replaces the inline
+// string with the returned key.
+//
+// Idempotent: only reports whose `image` is still an inline SVG (starts with '<') are
+// touched, so re-running is a no-op. Run with: `node scripts/migrate-ioda-svg-to-storage.js`.
+
+process.title = 'aggie-migrate-ioda-svg';
+
+const database = require('../backend/database');
+const Report = require('../backend/models/report');
+const { persistSvgChart } = require('../backend/fetching/utils/socialImageStorage');
+require('dotenv').config();
+
+function isInlineSvg(value) {
+  return typeof value === 'string' && value.trimStart().startsWith('<');
+}
+
+async function migrate() {
+  // Match reports whose chart image is still an inline SVG string.
+  const cursor = Report.find({
+    _media: 'ioda',
+    'metadata.rawAPIResponse.image': /^\s*</,
+  }).cursor();
+
+  let migrated = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (let report = await cursor.next(); report != null; report = await cursor.next()) {
+    const svg = report.metadata && report.metadata.rawAPIResponse
+      ? report.metadata.rawAPIResponse.image
+      : null;
+
+    if (!isInlineSvg(svg)) {
+      skipped += 1; // already migrated (holds a key) or no image
+      continue;
+    }
+
+    try {
+      const key = await persistSvgChart({ svg, guid: report.guid });
+      if (!key) {
+        failed += 1;
+        console.error(`No key returned for report ${report._id} (guid=${report.guid}).`);
+        continue;
+      }
+      report.metadata.rawAPIResponse.image = key;
+      report.markModified('metadata');
+      await report.save();
+      migrated += 1;
+      if (migrated % 100 === 0) console.log(`...migrated ${migrated} so far`);
+    } catch (err) {
+      failed += 1;
+      console.error(`Failed migrating report ${report._id} (guid=${report.guid}):`, err.message);
+    }
+  }
+
+  console.log(`Done. migrated=${migrated}, skipped=${skipped}, failed=${failed}.`);
+}
+
+database.mongoose.connection.once('open', async () => {
+  try {
+    await migrate();
+    process.exit(0);
+  } catch (err) {
+    console.error('Migration aborted:', err);
+    process.exit(1);
+  }
+});

--- a/src/api/reports/types.ts
+++ b/src/api/reports/types.ts
@@ -91,6 +91,9 @@ interface RawApiResponse {
   id: string;
   type: string;
   attributes: unknown;
+  // IODA/Cloudflare chart: `image` is the media-storage key, `imageUrl` the served URL.
+  image?: string;
+  imageUrl?: string;
   [key: string]: any;
 }
 // i need to redo this...

--- a/src/components/SocialMediaPost/IodaEvent.tsx
+++ b/src/components/SocialMediaPost/IodaEvent.tsx
@@ -1,4 +1,3 @@
-import { isObject, isString } from "lodash";
 import { Report } from "../../api/reports/types";
 import { signalToNameColor } from "../SocialMediaPost/reportParser";
 import AggieToken from "../AggieToken";
@@ -16,11 +15,6 @@ const IodaEvent = ({ report }: IProps) => {
   const rawSignal = rawData?.rawEvent?.datasource;
   let [signal, bgColor] = signalToNameColor(rawSignal);
 
-  const image = rawData?.image?.
-    replace('width="726"', 'width="100%"').
-    replace('width="733"', 'width="100%"').
-    replace('height="514"', 'height="auto"') || "";
-
   return (
     <>
       <div className='flex gap-2 items-center'>
@@ -34,7 +28,7 @@ const IodaEvent = ({ report }: IProps) => {
       <p className='mb-1'>
         {start} - {end} UTC
       </p>
-      <div dangerouslySetInnerHTML={{ __html: image }} />
+      <img src={rawData?.imageUrl} alt='outage chart' className='w-full h-auto' />
     </>
   );
 };

--- a/src/components/SocialMediaPost/TrafficEvent.tsx
+++ b/src/components/SocialMediaPost/TrafficEvent.tsx
@@ -17,7 +17,7 @@ const TrafficEvent = ({ report }: IProps) => {
           report?.authoredAt?.replace('T', ' ').substring(0, 16)
         } - {endDate.replace('T', ' ').substring(0, 16)} UTC
       </p>
-      <img src={rawData?.imageUrl} alt='traffic trend' />
+      <img src={rawData?.imageUrl ?? rawData?.image} alt='traffic trend' />
     </>
   );
 };

--- a/src/components/SocialMediaPost/TrafficEvent.tsx
+++ b/src/components/SocialMediaPost/TrafficEvent.tsx
@@ -17,7 +17,7 @@ const TrafficEvent = ({ report }: IProps) => {
           report?.authoredAt?.replace('T', ' ').substring(0, 16)
         } - {endDate.replace('T', ' ').substring(0, 16)} UTC
       </p>
-      <img src={rawData?.image} alt='traffic trend' />
+      <img src={rawData?.imageUrl} alt='traffic trend' />
     </>
   );
 };


### PR DESCRIPTION
Title: Move IODA chart SVGs from MongoDB into media storage

> ⚠️ **Base branch:** stacked on `fix/reports-timeout-double-send`. The diff includes the reports-timeout fix, so that branch can be deleted.

## Summary

IODA outage reports stored a ~330KB chart SVG inline at `metadata.rawAPIResponse.image`, re-written on every poll. That bloated every IODA document (~440KB avg vs ~1KB for other reports) and was the root cause of the alerts-list timeouts. This stores each chart as a file served over `/media` and keeps only a small key on the document.

## What was done

- **New storage helper** `persistSvgChart({ svg, guid })` in `backend/fetching/utils/socialImageStorage.js` — writes the SVG to `ioda/charts/<sha1(guid)>.svg` and returns the key. Keyed by `guid` so re-fetches overwrite the same file in place (no orphans). Also exported the existing `deleteMediaByKey`.
- **IODA channel** (`backend/fetching/channels/ioda.js`) — still scrapes the SVG once per linked page (caches the string), but now persists per-`guid` and stores the **key** in `raw.image`. Covers both the new-report and the every-poll overwrite paths.
- **API serializer** (`reportController.js`) — `serializeReport` emits `rawAPIResponse.imageUrl` from the key, with a guard so any legacy inline-SVG report still renders during rollout.
- **Frontend** — `IodaEvent.tsx` / `TrafficEvent.tsx` render `<img src={imageUrl}>` (dropped the `dangerouslySetInnerHTML` SVG-string path); added `image`/`imageUrl` to the `RawApiResponse` type.
- **Removed the band-aid** — dropped the `.select({…image: 0})` list-query exclusion added in the timeout fix; documents are small now, so list/table views get the chart URL back.
- **One-off migration** — `scripts/migrate-ioda-svg-to-storage.js` backfills existing reports (idempotent).

## Verified (dev)

- Migration: **916 migrated, 0 skipped, 0 failed**; re-run = 0 (idempotent).
- Alerts list: **~90KB / 0.3s** (was ~43MB / 60s timeout), now carrying the key + `imageUrl`.
- `/media/ioda/charts/<sha1>.svg` → 200, `image/svg+xml`.
- `npx tsc --noEmit` clean.

## Still to do / confirm

- **Visual check:** report detail renders the chart, and the alert table / compare modal render charts (lazy-loaded via `<img>`). Not yet eyeballed in the browser.
- **Live fetch path:** confirm a brand-new IODA poll writes a key (not an inline SVG), and that repeated polls of the same ongoing outage don't grow the file count under `ioda/charts/`. Verified indirectly (migration uses the same helper) but not on a live fetch.
- **Optional, deferred:** delete the chart file on report deletion (call `deleteMediaByKey(...)`); low priority since files are bounded one-per-event.

## How to deploy

The migration is a **required deploy step**, not optional cleanup — because this PR removes the list-query band-aid, any un-migrated IODA report would otherwise reintroduce the 43MB/timeout problem and won't render its chart.

On the deployment VM, from the deployed checkout (so `.env`, `node_modules`, and `public/media` are the right ones), run **as the app/PM2 user**:

1. Deploy the code.
2. `node scripts/migrate-ioda-svg-to-storage.js` (connects to the env's DB, writes files to the repo's `public/media/ioda/charts/`).
3. Restart / start serving.

Notes:

- Must run **on the VM** (or wherever the media dir the API serves `/media` from lives) — the SVGs are written to local disk; running it elsewhere would leave DB keys pointing at files the API can't find.
- Run as the same user that runs the app, so the API can read the new files.
- Idempotent — safe to re-run if unsure it finished.