### PR TITLE
Populate and normalize user team data in user API

### DIFF
--- a/backend/api/controllers/userController.js
+++ b/backend/api/controllers/userController.js
@@ -8,6 +8,11 @@ const teamPopulate = {
   select: 'name description active',
 };
 
+const normalizeUserTeams = (user) => ({
+  ...user,
+  teams: user.teams || [],
+});
+
 
 // get user list
 exports.user_users = (req, res) => {
@@ -23,7 +28,7 @@ exports.user_users = (req, res) => {
           .status(err.status || 500)
           .send(err.message || "User query failed");
       }
-      return res.status(200).send(users);
+      return res.status(200).send(users.map(normalizeUserTeams));
     });
 };
 
@@ -57,7 +62,7 @@ exports.user_manageableUsers = (req, res) => {
           .status(err.status || 500)
           .send(err.message || "User query failed");
       }
-      return res.status(200).send(users);
+      return res.status(200).send(users.map(normalizeUserTeams));
     });
 };
 
@@ -67,6 +72,7 @@ exports.user_detail = (req, res) => {
 
   User.findById(req.params._id, '-password')
     .populate(teamPopulate)
+    .lean()
     .exec(function (err, user) {
       if (err) { return res.status(err.status).send(err.message); }
       else if (!user) { return res.sendStatus(404); }
@@ -85,7 +91,7 @@ exports.user_detail = (req, res) => {
         }
 
         if (!allowed) return res.status(403).send('Unauthorized to view the user.');
-        return res.status(200).send(user);
+        return res.status(200).send(normalizeUserTeams(user));
       }
     });
 };

--- a/backend/api/controllers/userController.js
+++ b/backend/api/controllers/userController.js
@@ -3,6 +3,11 @@ var User = require('../../models/user');
 const passport = require('passport');
 const validator = require('validator');
 
+const teamPopulate = {
+  path: 'teams',
+  select: 'name description active',
+};
+
 
 // get user list
 exports.user_users = (req, res) => {
@@ -10,6 +15,7 @@ exports.user_users = (req, res) => {
 
   User.find({})
     .select("-password")
+    .populate(teamPopulate)
     .lean()
     .exec((err, users) => {
       if (err) {
@@ -43,6 +49,7 @@ exports.user_manageableUsers = (req, res) => {
 
   User.find(filter)
     .select("-password")
+    .populate(teamPopulate)
     .lean()
     .exec((err, users) => {
       if (err) {
@@ -58,27 +65,29 @@ exports.user_manageableUsers = (req, res) => {
 exports.user_detail = (req, res) => {
   if (!req.user) return res.status(401).send('Unauthenticated.');
 
-  User.findById(req.params._id, '-password', function (err, user) {
-    if (err) { return res.status(err.status).send(err.message); }
-    else if (!user) { return res.sendStatus(404); }
-    else {
-      const role = req.user.role;
-      const isSelf = String(user._id) === String(req.user._id);
-      let allowed = false;
+  User.findById(req.params._id, '-password')
+    .populate(teamPopulate)
+    .exec(function (err, user) {
+      if (err) { return res.status(err.status).send(err.message); }
+      else if (!user) { return res.sendStatus(404); }
+      else {
+        const role = req.user.role;
+        const isSelf = String(user._id) === String(req.user._id);
+        let allowed = false;
 
-      if (role === 'admin') {
-        allowed = true; 
-      } else if (role === 'team_lead') {
-        const createdByMe = String(user.createdBy) === String(req.user._id);
-        allowed = isSelf || createdByMe; 
-      } else {
-        allowed = isSelf; 
+        if (role === 'admin') {
+          allowed = true;
+        } else if (role === 'team_lead') {
+          const createdByMe = String(user.createdBy) === String(req.user._id);
+          allowed = isSelf || createdByMe;
+        } else {
+          allowed = isSelf;
+        }
+
+        if (!allowed) return res.status(403).send('Unauthorized to view the user.');
+        return res.status(200).send(user);
       }
-
-      if (!allowed) return res.status(403).send('Unauthorized to view the user.');
-      return res.status(200).send(user);
-    }
-  });
+    });
 };
 
 // Create a new User


### PR DESCRIPTION
Description:
This PR updates the user API responses to include team information.

Populates the teams field when returning users.
Applies this to the user list, manageable user list, and individual user detail response.
Normalizes older users without assigned teams so they return teams: [] instead of leaving the field undefined.

This does not add any team-based enforcement yet. It only makes team membership visible through the existing user API so we can build membership management and scoped access on top of it later.

Local checks:

Confirmed /api/team returns an empty list when no teams exist.
Confirmed /api/user returns users with teams: [].