### PR TITLE
Feat/access control

### DIFF
--- a/backend/api/controllers/userController.js
+++ b/backend/api/controllers/userController.js
@@ -2,7 +2,12 @@
 var User = require('../../models/user');
 const passport = require('passport');
 const validator = require('validator');
+const Team = require('../../models/team');
+const database = require('../../database');
+const mongoose = database.mongoose;
 
+
+// helpers for team items
 const teamPopulate = {
   path: 'teams',
   select: 'name description active',
@@ -12,6 +17,12 @@ const normalizeUserTeams = (user) => ({
   ...user,
   teams: user.teams || [],
 });
+
+const normalizeIds = (ids) => [
+  ...new Set((ids || []).map((id) => String(id._id || id)).filter(Boolean)),
+];
+
+const isValidObjectId = (id) => mongoose.Types.ObjectId.isValid(id);
 
 
 // get user list
@@ -156,6 +167,89 @@ exports.user_create = (req, res) => {
     }
   });*/
 };
+
+// Update a user's team memberships
+exports.user_update_teams = async (req, res) => {
+  if (!req.user) return res.status(401).send('Unauthenticated.');
+
+  if (!Array.isArray(req.body.teams)) {
+    return res.status(400).send('Please provide teams as an array.');
+  }
+
+  const requestedTeamIds = normalizeIds(req.body.teams);
+
+  if (requestedTeamIds.some((id) => !isValidObjectId(id))) {
+    return res.status(400).send('One or more team ids are invalid.');
+  }
+
+  try {
+    const actor = await User.findById(req.user._id)
+      .select('role teams')
+      .lean();
+
+    const targetUser = await User.findById(req.params._id)
+      .select('-password')
+      .lean();
+
+    if (!actor) return res.status(401).send('Unauthenticated.');
+    if (!targetUser) return res.sendStatus(404);
+
+    const teams = await Team.find({ _id: { $in: requestedTeamIds } })
+      .select('_id')
+      .lean();
+
+    if (teams.length !== requestedTeamIds.length) {
+      return res.status(400).send('One or more teams were not found.');
+    }
+
+    const isAdmin = actor.role === 'admin';
+    const isTeamLead = actor.role === 'team_lead';
+    const isSelf = String(actor._id) === String(targetUser._id);
+
+    if (!isAdmin && !isTeamLead) {
+      return res.status(403).send('Unauthorized to update user teams.');
+    }
+
+    if (!isAdmin && isSelf) {
+      return res.status(403).send('Users cannot update their own team memberships.');
+    }
+
+    if (isTeamLead) {
+      if (!['viewer', 'monitor'].includes(targetUser.role)) {
+        return res.status(403).send('Team leads can only manage viewer or monitor team memberships.');
+      }
+
+      const actorTeamIds = new Set(normalizeIds(actor.teams));
+      const currentTeamIds = normalizeIds(targetUser.teams);
+
+      const addedTeamIds = requestedTeamIds.filter((id) => !currentTeamIds.includes(id));
+      const removedTeamIds = currentTeamIds.filter((id) => !requestedTeamIds.includes(id));
+      const changedTeamIds = [...addedTeamIds, ...removedTeamIds];
+
+      const hasUnauthorizedTeamChange = changedTeamIds.some((id) => !actorTeamIds.has(id));
+
+      if (hasUnauthorizedTeamChange) {
+        return res.status(403).send('Team leads can only manage teams they belong to.');
+      }
+    }
+
+    const updatedUser = await User.findByIdAndUpdate(
+      req.params._id,
+      { teams: requestedTeamIds },
+      { new: true }
+    )
+      .select('-password')
+      .populate(teamPopulate)
+      .lean();
+
+    return res.status(200).send(normalizeUserTeams(updatedUser));
+  } catch (err) {
+    return res
+      .status(err.status || 500)
+      .send(err.message || 'User team update failed');
+  }
+};
+
 
 // Update a User
 exports.user_update = (req, res) => {

--- a/backend/api/routes/userRoutes.js
+++ b/backend/api/routes/userRoutes.js
@@ -17,6 +17,9 @@ router.post('', User.can('change settings'), userController.user_create);
 // Get Individual User
 router.get('/:_id', User.can('view users'), userController.user_detail);
 
+// Update User teams
+router.put('/:_id/teams', userController.user_update_teams);
+
 // Update Users
 router.put('/:_id', User.can('update users'), userController.user_update);
 

--- a/src/api/users/types.ts
+++ b/src/api/users/types.ts
@@ -3,6 +3,13 @@ import { hasId } from "../common";
 export const USER_ROLES = ["viewer", "monitor", "admin", "team_lead"] as const;
 export type UserRoles = (typeof USER_ROLES)[number];
 
+export interface UserTeam {
+  _id: string;
+  name: string;
+  description?: string;
+  active?: boolean;
+}
+
 export interface User extends hasId {
   provider: string;
   hasDefaultPassword: boolean;
@@ -10,6 +17,7 @@ export interface User extends hasId {
   email: string;
   username: string;
   displayName?: string;
+  teams?: UserTeam[];
   __v: number;
   createdBy?: string;
   mfa?: {

--- a/src/pages/Settings/user/UsersIndex.tsx
+++ b/src/pages/Settings/user/UsersIndex.tsx
@@ -51,6 +51,11 @@ const UsersIndex = ({ session }: IProps) => {
     (editUser === "newUser" && session?.role === "admin") || 
     (!!userToEdit && session?.role === "admin" && userToEdit._id !== session?._id);
 
+      function getTeamNames(user: { teams?: { name?: string }[] }) {
+    if (!user.teams || user.teams.length === 0) return "None";
+    return user.teams.map((team) => team.name || "Unnamed team").join(", ");
+  }
+
   return (
     <div className='w-full mb-16'>
       <div className='flex justify-between items-center'>
@@ -67,9 +72,10 @@ const UsersIndex = ({ session }: IProps) => {
       </div>
 
       <div className=' rounded-lg border border-slate-300 bg-white dark:bg-gray-800 divide-y divide-slate-300'>
-        <div className='grid grid-cols-4 px-3 py-3 font-medium text-sm border-b border-slate-300 items-baseline'>
+        <div className='grid grid-cols-5 px-3 py-3 font-medium text-sm border-b border-slate-300 items-baseline'>
           <p>Username</p>
           <p>Role</p>
+          <p>Teams</p>
           <p>Email</p>
           <div className='flex justify-end '></div>
         </div>
@@ -87,7 +93,7 @@ const UsersIndex = ({ session }: IProps) => {
             return (
             <article
               key={user._id}
-              className='grid grid-cols-4 px-3 py-3 items-center'
+              className='grid grid-cols-5 px-3 py-3 items-center'
             >
               <div className=''>
                 {!!user.displayName ? (
@@ -113,6 +119,9 @@ const UsersIndex = ({ session }: IProps) => {
               </div>
               <p className='px-2 py-1 bg-slate-200 dark:bg-gray-600 rounded text-sm w-fit font-medium'>
                 {user.role}
+              </p>
+              <p className='text-sm text-slate-600 dark:text-gray-300'>
+                {getTeamNames(user)}
               </p>
               <p>{user.email}</p>
               <div className='flex justify-end'>


### PR DESCRIPTION
This PR adds a frontend update to show user team membership in the settings user list.

Changes included:

Adds team data to the frontend user type.
Adds a Teams column to the user settings page.
Displays None when a user does not belong to any teams yet.

This does not add team assignment controls or enforce team-based access. It only makes the team membership data visible in the UI.