### PR TITLE
Team Lead membership allocation and Manageable team API

### DIFF
--- a/backend/api/controllers/teamController.js
+++ b/backend/api/controllers/teamController.js
@@ -1,5 +1,6 @@
 // Handles CRUD requests for teams.
 const Team = require('../../models/team');
+const User = require('../../models/user');
 
 // Get all teams
 exports.team_list = (req, res) => {
@@ -17,6 +18,43 @@ exports.team_list = (req, res) => {
 
       return res.status(200).send(teams);
     });
+};
+
+// Get teams the current user can manage
+exports.team_manageable_list = async (req, res) => {
+  if (!req.user) return res.status(401).send('Unauthenticated.');
+
+  try {
+    if (req.user.role === 'admin') {
+      const teams = await Team.find({})
+        .sort({ name: 1 })
+        .lean();
+
+      return res.status(200).send(teams);
+    }
+
+    if (req.user.role === 'team_lead') {
+      const actor = await User.findById(req.user._id)
+        .select('teams')
+        .lean();
+
+      if (!actor) return res.status(401).send('Unauthenticated.');
+
+      const teamIds = actor.teams || [];
+
+      const teams = await Team.find({ _id: { $in: teamIds } })
+        .sort({ name: 1 })
+        .lean();
+
+      return res.status(200).send(teams);
+    }
+
+    return res.status(403).send('Unauthorized to view manageable teams.');
+  } catch (err) {
+    return res
+      .status(err.status || 500)
+      .send(err.message || 'Manageable team query failed');
+  }
 };
 
 // Create a team

--- a/backend/api/controllers/userController.js
+++ b/backend/api/controllers/userController.js
@@ -54,12 +54,12 @@ exports.user_manageableUsers = (req, res) => {
     filter = {};
   } else if (role === "team_lead") {
     filter = {
-      $or: [
-        { _id: self },
-        { createdBy: self },
-      ],
-    };
-  } else {
+     $or: [
+      { _id: self },
+      { role: { $in: ["viewer", "monitor"] } },
+     ],
+   };
+} else {
     filter = { _id: self };
   }
 
@@ -92,14 +92,14 @@ exports.user_detail = (req, res) => {
         const isSelf = String(user._id) === String(req.user._id);
         let allowed = false;
 
-        if (role === 'admin') {
-          allowed = true;
-        } else if (role === 'team_lead') {
-          const createdByMe = String(user.createdBy) === String(req.user._id);
-          allowed = isSelf || createdByMe;
-        } else {
-          allowed = isSelf;
-        }
+      if (role === 'admin') {
+        allowed = true;
+    } else if (role === 'team_lead') {
+      const isViewerOrMonitor = ['viewer', 'monitor'].includes(user.role);
+      allowed = isSelf || isViewerOrMonitor;
+    } else {
+      allowed = isSelf;
+    }
 
         if (!allowed) return res.status(403).send('Unauthorized to view the user.');
         return res.status(200).send(normalizeUserTeams(user));
@@ -214,28 +214,29 @@ exports.user_update_teams = async (req, res) => {
       return res.status(403).send('Users cannot update their own team memberships.');
     }
 
+    let updatedTeamIds = requestedTeamIds;
+
     if (isTeamLead) {
       if (!['viewer', 'monitor'].includes(targetUser.role)) {
         return res.status(403).send('Team leads can only manage viewer or monitor team memberships.');
       }
 
       const actorTeamIds = new Set(normalizeIds(actor.teams));
-      const currentTeamIds = normalizeIds(targetUser.teams);
+      const requestedOutsideScope = requestedTeamIds.some((id) => !actorTeamIds.has(id));
 
-      const addedTeamIds = requestedTeamIds.filter((id) => !currentTeamIds.includes(id));
-      const removedTeamIds = currentTeamIds.filter((id) => !requestedTeamIds.includes(id));
-      const changedTeamIds = [...addedTeamIds, ...removedTeamIds];
-
-      const hasUnauthorizedTeamChange = changedTeamIds.some((id) => !actorTeamIds.has(id));
-
-      if (hasUnauthorizedTeamChange) {
-        return res.status(403).send('Team leads can only manage teams they belong to.');
+      if (requestedOutsideScope) {
+        return res.status(403).send('Team leads can only assign users to teams they belong to.');
       }
+
+      const currentTeamIds = normalizeIds(targetUser.teams);
+      const preservedTeamIds = currentTeamIds.filter((id) => !actorTeamIds.has(id));
+
+      updatedTeamIds = normalizeIds([...preservedTeamIds, ...requestedTeamIds]);
     }
 
     const updatedUser = await User.findByIdAndUpdate(
       req.params._id,
-      { teams: requestedTeamIds },
+      { teams: updatedTeamIds },
       { new: true }
     )
       .select('-password')

--- a/backend/api/routes/teamRoutes.js
+++ b/backend/api/routes/teamRoutes.js
@@ -4,6 +4,9 @@ const router = express.Router();
 const teamController = require('../controllers/teamController');
 const User = require('../../models/user');
 
+// Get teams manageable by current user
+router.get('/manageable', teamController.team_manageable_list);
+
 // Get all teams
 router.get('', User.can('admin users'), teamController.team_list);
 

--- a/backend/api/routes/teamRoutes.js
+++ b/backend/api/routes/teamRoutes.js
@@ -5,7 +5,7 @@ const teamController = require('../controllers/teamController');
 const User = require('../../models/user');
 
 // Get all teams
-router.get('', teamController.team_list);
+router.get('', User.can('admin users'), teamController.team_list);
 
 // Create a team
 router.post('', User.can('admin users'), teamController.team_create);

--- a/backend/api/routes/userRoutes.js
+++ b/backend/api/routes/userRoutes.js
@@ -8,14 +8,14 @@ const User = require('../../models/user');
 router.get('', User.can('view users'), userController.user_users);
 
 // Get a list of manageable Users
-router.get('/manageable', User.can('view users'), userController.user_manageableUsers);
+router.get('/manageable', userController.user_manageableUsers);
 
 
 // Create a user
 router.post('', User.can('change settings'), userController.user_create);
 
 // Get Individual User
-router.get('/:_id', User.can('view users'), userController.user_detail);
+router.get('/:_id', userController.user_detail);
 
 // Update User teams
 router.put('/:_id/teams', userController.user_update_teams);

--- a/src/api/teams/index.ts
+++ b/src/api/teams/index.ts
@@ -1,0 +1,7 @@
+import axios from "axios";
+import type { Team } from "./types";
+
+export const getTeams = async () => {
+  const { data } = await axios.get<Team[]>("/api/team");
+  return data;
+};

--- a/src/api/teams/index.ts
+++ b/src/api/teams/index.ts
@@ -5,3 +5,8 @@ export const getTeams = async () => {
   const { data } = await axios.get<Team[]>("/api/team");
   return data;
 };
+
+export const getManageableTeams = async () => {
+  const { data } = await axios.get<Team[]>("/api/team/manageable");
+  return data;
+};

--- a/src/api/teams/types.ts
+++ b/src/api/teams/types.ts
@@ -1,0 +1,7 @@
+import { hasId } from "../common";
+
+export interface Team extends hasId {
+  name: string;
+  description?: string;
+  active?: boolean;
+}

--- a/src/api/users/index.ts
+++ b/src/api/users/index.ts
@@ -41,3 +41,10 @@ export const setPassword = async (params: { _id: string; pass: string }) => {
   });
   return data;
 };
+
+export const updateUserTeams = async (params: { _id: string; teams: string[] }) => {
+  const { data } = await axios.put<User>("/api/user/" + params._id + "/teams", {
+    teams: params.teams,
+  });
+  return data;
+};

--- a/src/pages/Settings/user/UserProfile.tsx
+++ b/src/pages/Settings/user/UserProfile.tsx
@@ -4,7 +4,7 @@ import { useNavigate, useParams } from "react-router-dom";
 
 import { deleteUser, getUser, updateUserTeams } from "../../../api/users";
 import type { Session, WebAuthnDevice } from "../../../api/session/types";
-import { getTeams } from "../../../api/teams";
+import { getManageableTeams } from "../../../api/teams";
 
 import PlaceholderDiv from "../../../components/PlaceholderDiv";
 
@@ -38,9 +38,11 @@ const UserProfile = ({ session }: IProps) => {
 
   const role = session?.role as UserRoles | undefined;
   const isAdmin = role === "admin";
+  const isTeamLead = role === "team_lead";
+  const isSelf = session?._id === params.id;
 
-  const { data: teams } = useQuery(["teams"], getTeams, {
-    enabled: isAdmin,
+  const { data: teams } = useQuery(["teams", "manageable"], getManageableTeams, {
+    enabled: isAdmin || isTeamLead,
   });
 
   const [selectedTeamIds, setSelectedTeamIds] = useState<string[]>([]);
@@ -57,7 +59,7 @@ const UserProfile = ({ session }: IProps) => {
     },
   });
 
-    const doUpdateUserTeams = useMutation(updateUserTeams, {
+  const doUpdateUserTeams = useMutation(updateUserTeams, {
     onSuccess: () => {
       refetch();
       queryClient.invalidateQueries(["users"]);
@@ -66,18 +68,33 @@ const UserProfile = ({ session }: IProps) => {
   });
 
   function toggleTeam(teamId: string, checked: boolean) {
-  setSelectedTeamIds((current) =>
-    checked
-      ? [...new Set([...current, teamId])]
-      : current.filter((id) => id !== teamId)
-  );}
+    setSelectedTeamIds((current) =>
+      checked
+        ? [...new Set([...current, teamId])]
+        : current.filter((id) => id !== teamId)
+    );
+  }
 
   useEffect(() => {
-    setSelectedTeamIds((data?.teams || []).map((team) => team._id));
-  }, [data]);
+    const manageableTeamIds = new Set((teams || []).map((team) => team._id));
 
-  const isSelf = session?._id === params.id;
-  const isTeamLead = role === 'team_lead';
+    setSelectedTeamIds(
+      (data?.teams || [])
+        .filter((team) => manageableTeamIds.has(team._id))
+        .map((team) => team._id)
+    );
+  }, [data, teams]);
+
+  const targetRole = data?.role;
+  const canManageUserTeams =
+    isAdmin ||
+    (
+      isTeamLead &&
+      !isSelf &&
+      !!targetRole &&
+      ["viewer", "monitor"].includes(targetRole)
+    );
+
   const canEdit = !!isSelf || (isAdmin && !isSelf);
   const canEditRole = isAdmin && !isSelf;
   const canDeleteAsTeamLead = isTeamLead && !!data && String(data.createdBy) === String(session?._id) && !isSelf;
@@ -157,7 +174,7 @@ const UserProfile = ({ session }: IProps) => {
           <p className='mt-1'>{data?.email}</p>
         </PlaceholderDiv>
 
-                {isAdmin && data && (
+                {canManageUserTeams && data && (
           <div className='border-t border-slate-300 mt-3 pt-3'>
             <h3 className='font-medium text-lg mb-2'>Teams</h3>
 

--- a/src/pages/Settings/user/UserProfile.tsx
+++ b/src/pages/Settings/user/UserProfile.tsx
@@ -1,9 +1,10 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useParams } from "react-router-dom";
 
-import { deleteUser, getUser } from "../../../api/users";
+import { deleteUser, getUser, updateUserTeams } from "../../../api/users";
 import type { Session, WebAuthnDevice } from "../../../api/session/types";
+import { getTeams } from "../../../api/teams";
 
 import PlaceholderDiv from "../../../components/PlaceholderDiv";
 
@@ -35,6 +36,15 @@ const UserProfile = ({ session }: IProps) => {
     else return undefined;
   });
 
+  const role = session?.role as UserRoles | undefined;
+  const isAdmin = role === "admin";
+
+  const { data: teams } = useQuery(["teams"], getTeams, {
+    enabled: isAdmin,
+  });
+
+  const [selectedTeamIds, setSelectedTeamIds] = useState<string[]>([]);
+
   const queryClient = useQueryClient();
   const [openEdit, setOpenEdit] = useState(false);
   const [openDelete, setOpenDelete] = useState(false);
@@ -47,9 +57,26 @@ const UserProfile = ({ session }: IProps) => {
     },
   });
 
+    const doUpdateUserTeams = useMutation(updateUserTeams, {
+    onSuccess: () => {
+      refetch();
+      queryClient.invalidateQueries(["users"]);
+      if (params.id) queryClient.invalidateQueries(["users", params.id]);
+    },
+  });
+
+  function toggleTeam(teamId: string, checked: boolean) {
+  setSelectedTeamIds((current) =>
+    checked
+      ? [...new Set([...current, teamId])]
+      : current.filter((id) => id !== teamId)
+  );}
+
+  useEffect(() => {
+    setSelectedTeamIds((data?.teams || []).map((team) => team._id));
+  }, [data]);
+
   const isSelf = session?._id === params.id;
-  const role = session?.role as UserRoles | undefined;
-  const isAdmin = role === 'admin';
   const isTeamLead = role === 'team_lead';
   const canEdit = !!isSelf || (isAdmin && !isSelf);
   const canEditRole = isAdmin && !isSelf;
@@ -129,6 +156,50 @@ const UserProfile = ({ session }: IProps) => {
           <p className=''>Email</p>
           <p className='mt-1'>{data?.email}</p>
         </PlaceholderDiv>
+
+                {isAdmin && data && (
+          <div className='border-t border-slate-300 mt-3 pt-3'>
+            <h3 className='font-medium text-lg mb-2'>Teams</h3>
+
+            {!!teams && teams.length > 0 ? (
+              <div className='flex flex-col gap-2'>
+                {teams.map((team) => (
+                  <label key={team._id} className='flex items-center gap-2 text-sm'>
+                    <input
+                      type='checkbox'
+                      checked={selectedTeamIds.includes(team._id)}
+                      onChange={(event) => toggleTeam(team._id, event.target.checked)}
+                    />
+                    <span>
+                      {team.name}
+                      {team.active === false && " (inactive)"}
+                    </span>
+                  </label>
+                ))}
+              </div>
+            ) : (
+              <p className='text-sm text-slate-600 dark:text-gray-300'>
+                No teams have been created yet.
+              </p>
+            )}
+
+            <div className='mt-3'>
+              <AggieButton
+                variant='primary'
+                disabled={doUpdateUserTeams.isLoading}
+                loading={doUpdateUserTeams.isLoading}
+                onClick={() =>
+                  doUpdateUserTeams.mutate({
+                    _id: data._id,
+                    teams: selectedTeamIds,
+                  })
+                }
+              >
+                Save Teams
+              </AggieButton>
+            </div>
+          </div>
+        )}
 
         <SecuritySection
           session={session}


### PR DESCRIPTION

This PR adds support for team leads to manage team membership within their assigned teams.

Changes included:

Adds a manageable teams endpoint.
Lets admins access all teams for assignment.
Lets team leads access only the teams they belong to.
Allows team leads to assign viewer/monitor users to their own teams.
Preserves any team memberships outside the team lead’s scope.
Keeps initial team lead assignment admin-controlled.
Prevents team leads from managing their own team membership or assigning admin/team_lead users.

This builds on the existing admin team assignment flow and adds a safer scoped workflow for team leads.