### PR TITLE
Add teams settings page

### DIFF
--- a/backend/api/controllers/teamController.js
+++ b/backend/api/controllers/teamController.js
@@ -1,6 +1,6 @@
 // Handles CRUD requests for teams.
-const Team = require('../../models/team');
 const User = require('../../models/user');
+const Team = require('../../models/team');
 
 // Get all teams
 exports.team_list = (req, res) => {
@@ -76,4 +76,34 @@ exports.team_create = (req, res) => {
 
     return res.status(201).send(team);
   });
+};
+
+// Delete a team
+exports.team_delete = async (req, res) => {
+  if (!req.user) return res.status(401).send('Unauthenticated.');
+
+  if (req.user.role !== 'admin') {
+    return res.status(403).send('Unauthorized to delete teams.');
+  }
+
+  try {
+    const team = await Team.findById(req.params._id).lean();
+
+    if (!team) {
+      return res.sendStatus(404);
+    }
+
+    await User.updateMany(
+      { teams: req.params._id },
+      { $pull: { teams: req.params._id } }
+    );
+
+    await Team.findByIdAndDelete(req.params._id);
+
+    return res.status(200).send({ message: 'Team deleted.' });
+  } catch (err) {
+    return res
+      .status(err.status || 500)
+      .send(err.message || 'Team deletion failed');
+  }
 };

--- a/backend/api/routes/teamRoutes.js
+++ b/backend/api/routes/teamRoutes.js
@@ -13,4 +13,16 @@ router.get('', User.can('admin users'), teamController.team_list);
 // Create a team
 router.post('', User.can('admin users'), teamController.team_create);
 
+/*
+router.delete('/test-delete', (req, res) => {
+  return res.status(200).send('delete route works');
+});
+*/
+
+// Delete a team
+router.delete('/:_id', teamController.team_delete);
+
+//test for api call for delete
+//console.log('Loaded teamRoutes with DELETE /:_id');
+
 module.exports = router;

--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -16,6 +16,7 @@ import SourcesIndex from "./pages/Settings/source/SourcesIndex";
 import SourceDetails from "./pages/Settings/source/SourceDetails";
 import UsersIndex from "./pages/Settings/user/UsersIndex";
 import UserProfile from "./pages/Settings/user/UserProfile";
+import TeamsIndex from "./pages/Settings/team/TeamsIndex";
 import TagsIndex from "./pages/Settings/tag/TagsIndex";
 import CredentialsIndex from "./pages/Settings/Credentials/CredentialsIndex";
 import Login from "./pages/Login";
@@ -100,6 +101,10 @@ const PrivateRoutes = ({ sessionData }: IPrivateRouteProps) => {
             <Route path='users' element={<UsersIndex session={sessionData} />} />
             <Route path='credentials' element={<CredentialsIndex />} />
           </>
+        }
+        {sessionData?.role === "admin" && (
+            <Route path='teams' element={<TeamsIndex />} />
+         )
         }
       </Route>
       { sessionData?.role === "admin"

--- a/src/api/teams/index.ts
+++ b/src/api/teams/index.ts
@@ -10,3 +10,17 @@ export const getManageableTeams = async () => {
   const { data } = await axios.get<Team[]>("/api/team/manageable");
   return data;
 };
+
+export const createTeam = async (team: {
+  name: string;
+  description?: string;
+  active?: boolean;
+}) => {
+  const { data } = await axios.post<Team>("/api/team", team);
+  return data;
+};
+
+export const deleteTeam = async (teamId: string) => {
+  const { data } = await axios.delete("/api/team/" + teamId);
+  return data;
+};

--- a/src/pages/Settings/index.tsx
+++ b/src/pages/Settings/index.tsx
@@ -18,6 +18,7 @@ export function menuLinks(role: string | undefined) {
     case "admin":
       return {
         "Manage Users": { to: "users", icon: faUsersCog },
+        "Teams": { to: "teams", icon: faUsersCog },
         // "Manage Tags": { to: "tags", icon: faTags },
         "API Credentials": { to: "credentials", icon: faKey },
         "Manage Sources": { to: "sources", icon: faCloudArrowDown },

--- a/src/pages/Settings/team/TeamsIndex.tsx
+++ b/src/pages/Settings/team/TeamsIndex.tsx
@@ -1,0 +1,137 @@
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { createTeam, deleteTeam, getTeams } from "../../../api/teams";
+import AggieButton from "../../../components/AggieButton";
+import PlaceholderDiv from "../../../components/PlaceholderDiv";
+
+const TeamsIndex = () => {
+  const queryClient = useQueryClient();
+
+  const { data: teams, isLoading } = useQuery(["teams"], getTeams);
+
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+
+  const doCreateTeam = useMutation(createTeam, {
+    onSuccess: () => {
+      setName("");
+      setDescription("");
+      queryClient.invalidateQueries(["teams"]);
+      queryClient.invalidateQueries(["teams", "manageable"]);
+    },
+  });
+  const doDeleteTeam = useMutation(deleteTeam, {
+  onSuccess: () => {
+    queryClient.invalidateQueries(["teams"]);
+    queryClient.invalidateQueries(["teams", "manageable"]);
+    queryClient.invalidateQueries(["users"]);
+  },
+});
+
+  function onSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    const trimmedName = name.trim();
+    if (!trimmedName) return;
+
+    doCreateTeam.mutate({
+      name: trimmedName,
+      description: description.trim(),
+      active: true,
+    });
+  }
+
+  return (
+    <section className='mt-4'>
+      <div className='flex justify-between items-center mb-3'>
+        <h2 className='text-3xl font-medium'>Teams</h2>
+      </div>
+
+      <div className='grid grid-cols-1 lg:grid-cols-[1fr_320px] gap-4'>
+        <div className='bg-white dark:bg-gray-800 rounded-xl border border-slate-300 overflow-hidden'>
+          <div className='grid grid-cols-4 px-3 py-3 font-medium text-sm border-b border-slate-300'>
+            <p>Name</p>
+            <p>Description</p>
+            <p>Status</p>
+          </div>
+
+          <PlaceholderDiv loading={isLoading}>
+            {teams && teams.length > 0 ? (
+              teams.map((team) => (
+                <article
+                  key={team._id}
+                  className='grid grid-cols-4 px-3 py-3 items-center border-b border-slate-200 last:border-b-0'
+                >
+                  <p className='font-medium'>{team.name}</p>
+                  <p className='text-sm text-slate-600 dark:text-gray-300'>
+                    {team.description || "No description"}
+                  </p>
+                  <p className='text-sm'>
+                    {team.active === false ? "Inactive" : "Active"}
+                  </p>
+                  <div className='flex justify-end'>
+                    <AggieButton
+                      variant='danger'
+                      disabled={doDeleteTeam.isLoading}
+                      onClick={() => {
+                        if (window.confirm(`Delete team "${team.name}"? This will remove it from assigned users.`)) {
+                          doDeleteTeam.mutate(team._id);
+                        }
+                      }}
+                    >
+                      Delete
+                    </AggieButton>
+                  </div>
+                </article>
+              ))
+            ) : (
+              <div className='px-3 py-6 text-sm text-slate-600 dark:text-gray-300'>
+                No teams have been created yet.
+              </div>
+            )}
+          </PlaceholderDiv>
+        </div>
+
+        <form
+          onSubmit={onSubmit}
+          className='bg-white dark:bg-gray-800 rounded-xl border border-slate-300 p-3 h-fit flex flex-col gap-3'
+        >
+          <h3 className='text-xl font-medium'>Create team</h3>
+
+          <label className='flex flex-col gap-1 text-sm'>
+            <span className='font-medium'>Name</span>
+            <input
+              className='px-3 py-2 rounded border border-slate-300 dark:bg-gray-700'
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              placeholder='Team name'
+            />
+          </label>
+
+          <label className='flex flex-col gap-1 text-sm'>
+            <span className='font-medium'>Description</span>
+            <textarea
+              className='px-3 py-2 rounded border border-slate-300 dark:bg-gray-700'
+              value={description}
+              onChange={(event) => setDescription(event.target.value)}
+              placeholder='Optional description'
+              rows={4}
+            />
+          </label>
+
+          <AggieButton
+            variant='primary'
+            type='submit'
+            disabled={doCreateTeam.isLoading || !name.trim()}
+            loading={doCreateTeam.isLoading}
+          >
+            Create Team
+          </AggieButton>
+        </form>
+      </div>
+    </section>
+  );
+};
+
+export default TeamsIndex;


### PR DESCRIPTION
Description:
This PR adds an admin-facing Teams page under Settings.

Changes included:

Adds a Teams tab for admins.
Lists existing teams with name, description, and active status.
Adds a basic create team form.
Adds a delete option for teams.
Removes deleted teams from assigned users.
Keeps team creation and deletion admin-controlled.