### PR TITLE
Add team detail view

### DIFF
--- a/backend/api/controllers/teamController.js
+++ b/backend/api/controllers/teamController.js
@@ -57,6 +57,42 @@ exports.team_manageable_list = async (req, res) => {
   }
 };
 
+// Get a team with its assigned users
+exports.team_detail = async (req, res) => {
+  if (!req.user) return res.status(401).send('Unauthenticated.');
+
+  if (req.user.role !== 'admin') {
+    return res.status(403).send('Unauthorized to view team details.');
+  }
+
+  try {
+    const team = await Team.findById(req.params._id)
+      .lean();
+
+    if (!team) {
+      return res.sendStatus(404);
+    }
+
+    const members = await User.find({ teams: req.params._id })
+      .select('_id username displayName email role createdBy')
+      .sort({ role: 1, username: 1 })
+      .lean();
+
+    return res.status(200).send({
+      team,
+      members,
+    });
+  } catch (err) {
+    if (err.name === 'CastError') {
+      return res.status(400).send('Invalid team id.');
+    }
+
+    return res
+      .status(err.status || 500)
+      .send(err.message || 'Team detail query failed');
+  }
+};
+
 // Create a team
 exports.team_create = (req, res) => {
   if (!req.user) return res.status(401).send('Unauthenticated.');

--- a/backend/api/routes/teamRoutes.js
+++ b/backend/api/routes/teamRoutes.js
@@ -10,6 +10,9 @@ router.get('/manageable', teamController.team_manageable_list);
 // Get all teams
 router.get('', User.can('admin users'), teamController.team_list);
 
+// Get a team with its assigned users
+router.get('/:_id', teamController.team_detail);
+
 // Create a team
 router.post('', User.can('admin users'), teamController.team_create);
 

--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -17,6 +17,7 @@ import SourceDetails from "./pages/Settings/source/SourceDetails";
 import UsersIndex from "./pages/Settings/user/UsersIndex";
 import UserProfile from "./pages/Settings/user/UserProfile";
 import TeamsIndex from "./pages/Settings/team/TeamsIndex";
+import TeamDetails from "./pages/Settings/team/TeamDetails";
 import TagsIndex from "./pages/Settings/tag/TagsIndex";
 import CredentialsIndex from "./pages/Settings/Credentials/CredentialsIndex";
 import Login from "./pages/Login";
@@ -103,9 +104,11 @@ const PrivateRoutes = ({ sessionData }: IPrivateRouteProps) => {
           </>
         }
         {sessionData?.role === "admin" && (
+          <>
             <Route path='teams' element={<TeamsIndex />} />
-         )
-        }
+            <Route path='team/:id' element={<TeamDetails />} />
+          </>
+      )}
       </Route>
       { sessionData?.role === "admin"
         && (process.env.ENVIRONMENT === "development" || process.env.NODE_ENV === "development")

--- a/src/api/teams/index.ts
+++ b/src/api/teams/index.ts
@@ -1,8 +1,13 @@
 import axios from "axios";
-import type { Team } from "./types";
+import type { Team, TeamDetailResponse } from "./types";
 
 export const getTeams = async () => {
   const { data } = await axios.get<Team[]>("/api/team");
+  return data;
+};
+
+export const getTeam = async (teamId: string) => {
+  const { data } = await axios.get<TeamDetailResponse>("/api/team/" + teamId);
   return data;
 };
 

--- a/src/api/teams/types.ts
+++ b/src/api/teams/types.ts
@@ -5,3 +5,17 @@ export interface Team extends hasId {
   description?: string;
   active?: boolean;
 }
+
+export interface TeamMember {
+  _id: string;
+  username: string;
+  displayName?: string;
+  email: string;
+  role: string;
+  createdBy?: string;
+}
+
+export interface TeamDetailResponse {
+  team: Team;
+  members: TeamMember[];
+}

--- a/src/pages/Settings/team/TeamDetails.tsx
+++ b/src/pages/Settings/team/TeamDetails.tsx
@@ -1,0 +1,111 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link, useParams } from "react-router-dom";
+
+import { getTeam } from "../../../api/teams";
+import type { TeamMember } from "../../../api/teams/types";
+import PlaceholderDiv from "../../../components/PlaceholderDiv";
+
+const MemberList = ({
+  title,
+  members,
+}: {
+  title: string;
+  members: TeamMember[];
+}) => {
+  return (
+    <div className='bg-white dark:bg-gray-800 rounded-xl border border-slate-300 overflow-hidden'>
+      <div className='px-3 py-3 font-medium border-b border-slate-300'>
+        {title}
+      </div>
+
+      {members.length > 0 ? (
+        members.map((member) => (
+          <article
+            key={member._id}
+            className='grid grid-cols-3 px-3 py-3 border-b border-slate-200 last:border-b-0 items-center'
+          >
+            <p className='font-medium'>
+              {member.displayName || member.username}
+            </p>
+            <p className='text-sm text-slate-600 dark:text-gray-300'>
+              {member.email}
+            </p>
+            <p className='text-sm'>{member.role}</p>
+          </article>
+        ))
+      ) : (
+        <div className='px-3 py-4 text-sm text-slate-600 dark:text-gray-300'>
+          No users in this group.
+        </div>
+      )}
+    </div>
+  );
+};
+
+const TeamDetails = () => {
+  const params = useParams();
+
+  const { data, isLoading } = useQuery(["teams", params.id], () => {
+    if (params.id) return getTeam(params.id);
+    return undefined;
+  });
+
+  const members = data?.members || [];
+
+  const teamLeads = members.filter((member) => member.role === "team_lead");
+  const monitors = members.filter((member) => member.role === "monitor");
+  const viewers = members.filter((member) => member.role === "viewer");
+  const admins = members.filter((member) => member.role === "admin");
+  const otherMembers = members.filter(
+    (member) =>
+      !["admin", "team_lead", "monitor", "viewer"].includes(member.role)
+  );
+
+  return (
+    <section className='mt-4'>
+      <div className='mb-3'>
+        <Link
+          to='/settings/teams'
+          className='text-sm text-lime-800 hover:underline'
+        >
+          Back to Teams
+        </Link>
+      </div>
+
+      <PlaceholderDiv loading={isLoading}>
+        <div className='bg-white dark:bg-gray-800 rounded-xl border border-slate-300 p-3 mb-4'>
+          <div className='flex justify-between items-start gap-3'>
+            <div>
+              <h2 className='text-3xl font-medium'>
+                {data?.team.name || "Team"}
+              </h2>
+              <p className='text-sm text-slate-600 dark:text-gray-300 mt-1'>
+                {data?.team.description || "No description"}
+              </p>
+            </div>
+
+            <span className='text-sm px-2 py-1 bg-slate-100 dark:bg-gray-700 rounded border border-slate-300'>
+              {data?.team.active === false ? "Inactive" : "Active"}
+            </span>
+          </div>
+        </div>
+
+        <div className='flex flex-col gap-4'>
+          <MemberList title='Team Leads' members={teamLeads} />
+          <MemberList title='Monitors' members={monitors} />
+          <MemberList title='Viewers' members={viewers} />
+
+          {admins.length > 0 && (
+            <MemberList title='Admins' members={admins} />
+          )}
+
+          {otherMembers.length > 0 && (
+            <MemberList title='Other Members' members={otherMembers} />
+          )}
+        </div>
+      </PlaceholderDiv>
+    </section>
+  );
+};
+
+export default TeamDetails;

--- a/src/pages/Settings/team/TeamsIndex.tsx
+++ b/src/pages/Settings/team/TeamsIndex.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { createTeam, deleteTeam, getTeams } from "../../../api/teams";
+import { Link } from "react-router-dom";
 import AggieButton from "../../../components/AggieButton";
 import PlaceholderDiv from "../../../components/PlaceholderDiv";
 
@@ -63,7 +64,12 @@ const TeamsIndex = () => {
                   key={team._id}
                   className='grid grid-cols-4 px-3 py-3 items-center border-b border-slate-200 last:border-b-0'
                 >
-                  <p className='font-medium'>{team.name}</p>
+                  <Link 
+                    to={`/settings/team/${team._id}`}
+                    className='font-medium text-lime-800 hover:underline'
+                  >
+                    {team.name}
+                  </Link>
                   <p className='text-sm text-slate-600 dark:text-gray-300'>
                     {team.description || "No description"}
                   </p>


### PR DESCRIPTION
Made teams clickable from the Teams settings page
Added an admin-only team detail route
Added a backend endpoint to return a team and its assigned users
Shows team members grouped by role: team leads, monitors, and viewers
Added frontend API types/helpers for team details