### PR TITLE
Team Management overhaul + Source access control foundation

### DIFF
--- a/backend/access/sourceAccess.js
+++ b/backend/access/sourceAccess.js
@@ -1,0 +1,110 @@
+'use strict';
+
+const normalizeIds = (values) => {
+  if (!Array.isArray(values)) return [];
+
+  return values
+    .filter(Boolean)
+    .map((value) => {
+      if (value._id) return String(value._id);
+      return String(value);
+    });
+};
+
+const getUserTeamIds = (user) => {
+  if (!user || !Array.isArray(user.teams)) return [];
+  return normalizeIds(user.teams);
+};
+
+const getSourcePolicy = (source) => {
+  return source && source.accessPolicy
+    ? source.accessPolicy
+    : {
+        mode: 'public',
+        teams: [],
+        cutoffDate: null,
+      };
+};
+
+const hasTeamOverlap = (userTeamIds, allowedTeamIds) => {
+  const userTeams = new Set(userTeamIds);
+  return allowedTeamIds.some((teamId) => userTeams.has(teamId));
+};
+
+const isAdmin = (user) => {
+  return user && user.role === 'admin';
+};
+
+const canAccessRestrictedPolicy = (user, policy) => {
+  if (isAdmin(user)) return true;
+
+  const userTeamIds = getUserTeamIds(user);
+  const allowedTeamIds = normalizeIds(policy.teams);
+
+  if (allowedTeamIds.length === 0) return false;
+
+  return hasTeamOverlap(userTeamIds, allowedTeamIds);
+};
+
+const canViewSource = (user, source) => {
+  if (isAdmin(user)) return true;
+
+  const policy = getSourcePolicy(source);
+
+  if (!policy.mode || policy.mode === 'public') {
+    return true;
+  }
+
+  if (policy.mode === 'restricted') {
+    return canAccessRestrictedPolicy(user, policy);
+  }
+
+  if (policy.mode === 'public_until') {
+    return canAccessRestrictedPolicy(user, policy);
+  }
+
+  return false;
+};
+
+const canViewSourceDataForDate = (user, source, recordDate) => {
+  if (isAdmin(user)) return true;
+
+  const policy = getSourcePolicy(source);
+
+  if (!policy.mode || policy.mode === 'public') {
+    return true;
+  }
+
+  if (policy.mode === 'restricted') {
+    return canAccessRestrictedPolicy(user, policy);
+  }
+
+  if (policy.mode === 'public_until') {
+    if (!policy.cutoffDate) {
+      return canAccessRestrictedPolicy(user, policy);
+    }
+
+    if (!recordDate) {
+      return canAccessRestrictedPolicy(user, policy);
+    }
+
+    const cutoffDate = new Date(policy.cutoffDate);
+    const itemDate = new Date(recordDate);
+
+    if (itemDate < cutoffDate) {
+      return true;
+    }
+
+    return canAccessRestrictedPolicy(user, policy);
+  }
+
+  return false;
+};
+
+module.exports = {
+  canViewSource,
+  canViewSourceDataForDate,
+  getSourcePolicy,
+  getUserTeamIds,
+  normalizeIds,
+};

--- a/backend/api/controllers/sourceController.js
+++ b/backend/api/controllers/sourceController.js
@@ -4,15 +4,24 @@
 var Source = require('../../models/source');
 var _ = require('lodash');
 
+var sourcePopulate = [
+  { path: 'user', select: 'username' },
+  { path: 'credentials' },
+  { path: 'accessPolicy.teams', select: 'name description active' },
+];
+
 // Create a new Source
 exports.source_create = (req, res) => {
   // set user as the logged in user
   if (req.user) req.body.user = req.user._id;
+
+  normalizeAccessPolicy(req.body);
+
   Source.create(req.body, function (err, source) {
     if (err) {
       return res.status(err.status).send(err.message);
     }
-    
+
     res.status(200).send(source);
   });
 }
@@ -20,11 +29,8 @@ exports.source_create = (req, res) => {
 // Get a list of all sources
 exports.source_sources = (req, res) => {
   // Find all, exclude `events` field, populate user
-  Source.find({}, '-events', { sort: 'nickname' })
-    .populate([
-      { path: 'user', select: 'username' },
-      { path: 'credentials' }
-    ])
+ Source.find({}, '-events', { sort: 'nickname' })
+  .populate(sourcePopulate)
     .exec(function (err, sources) {
       if (err) res.status(err.status).send(err.message);
       else res.status(200).send(sources);
@@ -37,16 +43,42 @@ exports.source_details = (req, res) => {
     else if (!source) return res.sendStatus(404);
     Source.populate(
       source,
-      [
-        { path: 'user', select: 'username' },
-        { path: 'credentials' }
-      ],
+      sourcePopulate,
       function (err, source) {
         if (err) res.status(err.status).send(err.message);
         else res.status(200).send(source);
       });
   });
 }
+
+//helper for source.lpopulate
+var normalizeAccessPolicy = function (sourceData) {
+  if (!sourceData.accessPolicy) return;
+
+  var accessPolicy = sourceData.accessPolicy;
+
+  if (!accessPolicy.mode) {
+    accessPolicy.mode = 'public';
+  }
+
+  if (!Array.isArray(accessPolicy.teams)) {
+    accessPolicy.teams = [];
+  }
+
+  if (accessPolicy.cutoffDate === '') {
+    accessPolicy.cutoffDate = null;
+  }
+
+  if (accessPolicy.mode === 'public') {
+    accessPolicy.teams = [];
+    accessPolicy.cutoffDate = null;
+  }
+
+  if (accessPolicy.mode === 'restricted') {
+    accessPolicy.cutoffDate = null;
+  }
+};
+
 
 exports.source_update = (req, res, next) => {
   if (req.params._id === '_events') return next();
@@ -55,6 +87,8 @@ exports.source_update = (req, res, next) => {
     if (err) return res.status(err.status).send(err.message);
     if (!source) return res.sendStatus(404);
 
+    normalizeAccessPolicy(req.body);
+    
     // Update the actual values
     _.forEach(_.omit(req.body, ['_id', 'user', 'events']), function (val, key) {
       source[key] = val;

--- a/backend/api/controllers/teamController.js
+++ b/backend/api/controllers/teamController.js
@@ -2,9 +2,19 @@
 const User = require('../../models/user');
 const Team = require('../../models/team');
 
+const assignableRoles = ['viewer', 'monitor', 'team_lead'];
+
+const canManageTeams = (user) => {
+  return user && ['admin', 'team_lead'].includes(user.role);
+};
+
 // Get all teams
 exports.team_list = (req, res) => {
   if (!req.user) return res.status(401).send('Unauthenticated.');
+
+  if (!canManageTeams(req.user)) {
+    return res.status(403).send('Unauthorized to view teams.');
+  }
 
   Team.find({})
     .sort({ name: 1 })
@@ -61,10 +71,9 @@ exports.team_manageable_list = async (req, res) => {
 exports.team_detail = async (req, res) => {
   if (!req.user) return res.status(401).send('Unauthenticated.');
 
-  if (req.user.role !== 'admin') {
-    return res.status(403).send('Unauthorized to view team details.');
-  }
-
+  if (!canManageTeams(req.user)) {
+  return res.status(403).send('Unauthorized to view team details.');
+}
   try {
     const team = await Team.findById(req.params._id)
       .lean();
@@ -97,6 +106,10 @@ exports.team_detail = async (req, res) => {
 exports.team_create = (req, res) => {
   if (!req.user) return res.status(401).send('Unauthenticated.');
 
+  if (!canManageTeams(req.user)) {
+    return res.status(403).send('Unauthorized to create teams.');
+  }
+
   const payload = {
     name: req.body.name,
     description: req.body.description || '',
@@ -114,13 +127,123 @@ exports.team_create = (req, res) => {
   });
 };
 
+// Add or update a user's membership in a team
+exports.team_add_member = async (req, res) => {
+  if (!req.user) return res.status(401).send('Unauthenticated.');
+
+  if (!canManageTeams(req.user)) {
+    return res.status(403).send('Unauthorized to manage team members.');
+  }
+
+  const userId = req.body.userId;
+  const role = req.body.role;
+
+  if (!userId) {
+    return res.status(400).send('Please provide a userId.');
+  }
+
+  if (!assignableRoles.includes(role)) {
+    return res.status(400).send('Role must be viewer, monitor, or team_lead.');
+  }
+
+  try {
+    const team = await Team.findById(req.params._id).lean();
+
+    if (!team) {
+      return res.sendStatus(404);
+    }
+
+    const user = await User.findById(userId).select('-password');
+
+    if (!user) {
+      return res.status(404).send('User not found.');
+    }
+
+    if (user.role === 'admin') {
+      return res.status(403).send('Admin users cannot be assigned from the team page.');
+    }
+
+    user.role = role;
+    user.teams = user.teams || [];
+
+    const alreadyInTeam = user.teams.some(
+      (teamId) => String(teamId) === String(req.params._id)
+    );
+
+    if (!alreadyInTeam) {
+      user.teams.push(req.params._id);
+    }
+
+    await user.save();
+
+    const members = await User.find({ teams: req.params._id })
+      .select('_id username displayName email role createdBy')
+      .sort({ role: 1, username: 1 })
+      .lean();
+
+    return res.status(200).send({
+      team,
+      members,
+    });
+  } catch (err) {
+    return res
+      .status(err.status || 500)
+      .send(err.message || 'Team member update failed');
+  }
+};
+
+// Remove a user from a team
+exports.team_remove_member = async (req, res) => {
+  if (!req.user) return res.status(401).send('Unauthenticated.');
+
+  if (!canManageTeams(req.user)) {
+    return res.status(403).send('Unauthorized to manage team members.');
+  }
+
+  try {
+    const team = await Team.findById(req.params._id).lean();
+
+    if (!team) {
+      return res.sendStatus(404);
+    }
+
+    const user = await User.findById(req.params.userId).select('-password');
+
+    if (!user) {
+      return res.status(404).send('User not found.');
+    }
+
+    if (user.role === 'admin') {
+      return res.status(403).send('Admin users cannot be removed from teams here.');
+    }
+
+    await User.findByIdAndUpdate(req.params.userId, {
+      $pull: { teams: req.params._id },
+    });
+
+    const members = await User.find({ teams: req.params._id })
+      .select('_id username displayName email role createdBy')
+      .sort({ role: 1, username: 1 })
+      .lean();
+
+    return res.status(200).send({
+      team,
+      members,
+    });
+  } catch (err) {
+    return res
+      .status(err.status || 500)
+      .send(err.message || 'Team member removal failed');
+  }
+};
+
 // Delete a team
 exports.team_delete = async (req, res) => {
   if (!req.user) return res.status(401).send('Unauthenticated.');
 
-  if (req.user.role !== 'admin') {
-    return res.status(403).send('Unauthorized to delete teams.');
-  }
+if (!canManageTeams(req.user)) {
+  return res.status(403).send('Unauthorized to delete teams.');
+}
 
   try {
     const team = await Team.findById(req.params._id).lean();

--- a/backend/api/routes/teamRoutes.js
+++ b/backend/api/routes/teamRoutes.js
@@ -2,30 +2,37 @@
 const express = require('express');
 const router = express.Router();
 const teamController = require('../controllers/teamController');
-const User = require('../../models/user');
 
 // Get teams manageable by current user
 router.get('/manageable', teamController.team_manageable_list);
 
 // Get all teams
-router.get('', User.can('admin users'), teamController.team_list);
+router.get('', teamController.team_list);
+
+// Add or update a team member
+router.put('/:_id/member', teamController.team_add_member);
+
+// Remove a team member
+router.delete('/:_id/member/:userId', teamController.team_remove_member);
 
 // Get a team with its assigned users
 router.get('/:_id', teamController.team_detail);
 
 // Create a team
-router.post('', User.can('admin users'), teamController.team_create);
+router.post('', teamController.team_create);
+
+// Delete a team
+router.delete('/:_id', teamController.team_delete);
+
+/*
+test for api call for delete
+console.log('Loaded teamRoutes with DELETE /:_id');
+*/
 
 /*
 router.delete('/test-delete', (req, res) => {
   return res.status(200).send('delete route works');
 });
 */
-
-// Delete a team
-router.delete('/:_id', teamController.team_delete);
-
-//test for api call for delete
-//console.log('Loaded teamRoutes with DELETE /:_id');
 
 module.exports = router;

--- a/backend/models/source.js
+++ b/backend/models/source.js
@@ -43,6 +43,23 @@ var sourceSchema = new mongoose.Schema({
   user: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: false },
   tags: { type: [String], default: [] },
   credentials: { type: mongoose.Schema.Types.ObjectId, ref: 'Credentials', required: true },
+  accessPolicy: {
+    mode: {
+      type: String,
+      enum: ['public', 'restricted', 'public_until'],
+      default: 'public',
+      index: true,
+    },
+    teams: [{
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Team',
+      index: true,
+    }],
+    cutoffDate: {
+      type: Date,
+      default: null,
+    },
+  },
 });
 
 sourceSchema.pre('save', function (next) {

--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -103,12 +103,12 @@ const PrivateRoutes = ({ sessionData }: IPrivateRouteProps) => {
             <Route path='credentials' element={<CredentialsIndex />} />
           </>
         }
-        {sessionData?.role === "admin" && (
+        {(sessionData?.role === "admin" || sessionData?.role === "team_lead") && (
           <>
-            <Route path='teams' element={<TeamsIndex />} />
-            <Route path='team/:id' element={<TeamDetails />} />
-          </>
-      )}
+          <Route path='teams' element={<TeamsIndex session={sessionData} />} />
+          <Route path='team/:id' element={<TeamDetails session={sessionData} />} />
+        </>
+)}
       </Route>
       { sessionData?.role === "admin"
         && (process.env.ENVIRONMENT === "development" || process.env.NODE_ENV === "development")

--- a/src/api/sources/types.ts
+++ b/src/api/sources/types.ts
@@ -1,10 +1,19 @@
 import { hasId } from "../common";
 import { Credential } from "../credentials/types";
+import type { Team } from "../teams/types";
 
 interface SourceEvent {
   datetime: string;
   type: string;
   message: string;
+}
+
+export type SourceAccessMode = "public" | "restricted" | "public_until";
+
+export interface SourceAccessPolicy {
+  mode: SourceAccessMode;
+  teams: Team[] | string[];
+  cutoffDate?: string | null;
 }
 
 export interface Source extends hasId {
@@ -23,6 +32,7 @@ export interface Source extends hasId {
   keywords?: string;
   regex?: string;
   lists?: string;
+  accessPolicy?: SourceAccessPolicy;
   __v: number;
   lastReportDate?: string;
 }
@@ -34,4 +44,5 @@ export interface EditableSource extends hasId {
   url: string;
   keywords?: string;
   lists?: string;
+  accessPolicy?: SourceAccessPolicy;
 }

--- a/src/api/teams/index.ts
+++ b/src/api/teams/index.ts
@@ -29,3 +29,30 @@ export const deleteTeam = async (teamId: string) => {
   const { data } = await axios.delete("/api/team/" + teamId);
   return data;
 };
+
+export const addTeamMember = async (params: {
+  teamId: string;
+  userId: string;
+  role: string;
+}) => {
+  const { data } = await axios.put<TeamDetailResponse>(
+    "/api/team/" + params.teamId + "/member",
+    {
+      userId: params.userId,
+      role: params.role,
+    }
+  );
+
+  return data;
+};
+
+export const removeTeamMember = async (params: {
+  teamId: string;
+  userId: string;
+}) => {
+  const { data } = await axios.delete<TeamDetailResponse>(
+    "/api/team/" + params.teamId + "/member/" + params.userId
+  );
+
+  return data;
+};

--- a/src/pages/Settings/index.tsx
+++ b/src/pages/Settings/index.tsx
@@ -26,6 +26,7 @@ export function menuLinks(role: string | undefined) {
     case "team_lead":
       return {
         "Manage Users": { to: "users", icon: faUsersCog },
+        "Teams": { to: "teams", icon: faUsersCog },
         // "Manage Tags": { to: "tags", icon: faTags },
         "API Credentials": { to: "credentials", icon: faKey },
         "Manage Sources": { to: "sources", icon: faCloudArrowDown },

--- a/src/pages/Settings/source/CreateEditSourceForm.tsx
+++ b/src/pages/Settings/source/CreateEditSourceForm.tsx
@@ -6,7 +6,7 @@ import { useField } from "formik";
 
 import { getCredentials } from "../../../api/credentials";
 import { editSource, newSource } from "../../../api/sources";
-import type { Source } from "../../../api/sources/types";
+import type { Source, SourceAccessMode } from "../../../api/sources/types";
 
 import { Listbox } from "@headlessui/react";
 import FormikDropdown from "../../../components/FormikDropdown";
@@ -16,6 +16,9 @@ import FormikWithSchema from "../../../components/FormikWithSchema";
 import { faChevronDown, faCheck } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { CredentialOption, CREDENTIAL_OPTIONS } from "../../../api/common";
+
+import { getTeams } from "../../../api/teams";
+import type { Team } from "../../../api/teams/types";
 
 interface IProps {
   source?: Source;
@@ -50,6 +53,107 @@ const MastodonConditionalFields = () => {
   );
 };
 
+//helper for source access control
+//may change the date gating and go back to public vs private with team backing
+
+const getSourceAccessTeamIds = (source?: Source) => {
+  return (source?.accessPolicy?.teams || []).map((team) => {
+    if (typeof team === "string") return team;
+    return team._id;
+  });
+};
+
+const getSourceAccessInitialValues = (source?: Source) => ({
+  accessPolicyMode: source?.accessPolicy?.mode || "public",
+  accessPolicyTeams: getSourceAccessTeamIds(source),
+  accessPolicyCutoffDate: source?.accessPolicy?.cutoffDate
+    ? source.accessPolicy.cutoffDate.slice(0, 10)
+    : "",
+});
+
+const SourceAccessPolicyFields = ({ teams }: { teams?: Team[] }) => {
+  const [modeField] = useField<SourceAccessMode>("accessPolicyMode");
+  const [teamsField, , teamsHelpers] = useField<string[]>("accessPolicyTeams");
+  const [cutoffField] = useField<string>("accessPolicyCutoffDate");
+
+  const selectedTeamIds = teamsField.value || [];
+  const isRestricted =
+    modeField.value === "restricted" || modeField.value === "public_until";
+
+  const toggleTeam = (teamId: string) => {
+    if (selectedTeamIds.includes(teamId)) {
+      teamsHelpers.setValue(selectedTeamIds.filter((id) => id !== teamId));
+      return;
+    }
+
+    teamsHelpers.setValue([...selectedTeamIds, teamId]);
+  };
+
+  return (
+    <div className='mt-4 rounded border border-slate-300 bg-slate-50 dark:bg-gray-900 p-3'>
+      <h3 className='font-medium mb-1'>Access Policy</h3>
+      <p className='text-xs text-slate-500 dark:text-gray-400 mb-3'>
+        Controls whether this source is broadly visible or restricted to specific teams.
+      </p>
+
+      <FormikDropdown
+        list={[
+          { _id: "public", label: "Public" },
+          { _id: "restricted", label: "Restricted to teams" },
+          { _id: "public_until", label: "Public until cutoff date" },
+        ]}
+        label={"Access Mode"}
+        name={"accessPolicyMode"}
+      />
+
+      {modeField.value === "public_until" && (
+        <div className='flex flex-col gap-1 mb-3'>
+          <label className='text-slate-600 dark:text-gray-400'>
+            Cutoff Date
+          </label>
+          <input
+            {...cutoffField}
+            type='date'
+            className='px-3 py-2 focus-theme bg-white dark:bg-gray-800 border border-slate-300 rounded'
+          />
+          <p className='text-xs text-slate-500 dark:text-gray-400'>
+            Data before this date is treated as public. Data after this date is restricted to the selected teams.
+          </p>
+        </div>
+      )}
+
+
+      {isRestricted && (
+        <div className='flex flex-col gap-2'>
+          <label className='text-slate-600 dark:text-gray-400'>
+            Allowed Teams
+          </label>
+
+          {teams && teams.length > 0 ? (
+            teams.map((team) => (
+              <label
+                key={team._id}
+                className='flex items-center gap-2 text-sm'
+              >
+                <input
+                  type='checkbox'
+                  checked={selectedTeamIds.includes(team._id)}
+                  onChange={() => toggleTeam(team._id)}
+                />
+                <span>{team.name}</span>
+              </label>
+            ))
+          ) : (
+            <p className='text-xs text-slate-500 dark:text-gray-400'>
+              No teams available yet.
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
 const CreateEditSourceForm = ({ source, onClose }: IProps) => {
   const [credentialType, setCredentialType] =
     useState<CredentialOption>((source?.media as CredentialOption) || "ioda");
@@ -60,21 +164,48 @@ const CreateEditSourceForm = ({ source, onClose }: IProps) => {
     staleTime: 50000,
   });
 
+  const { data: teams } = useQuery(["teams"], getTeams, {
+    staleTime: 50000,
+  });
+
   const defaultCredential =
     credentials && credentials.find((cred) => cred.type === credentialType);
 
   const credentialsList =
     credentials && credentials.filter((cred) => cred.type === credentialType);
 
-  function onSubmit(data: any) {
-    data = { ...data, media: credentialType };
+  const sourceAccessInitialValues = getSourceAccessInitialValues(source);
 
-    if (!source) {
-      doCreateSource.mutate(data);
-      return;
-    }
-    doEditSource.mutate({ ...data, _id: source._id });
+function onSubmit(data: any) {
+  const {
+    accessPolicyMode,
+    accessPolicyTeams,
+    accessPolicyCutoffDate,
+    ...sourceData
+  } = data;
+
+  const accessPolicy = {
+    mode: accessPolicyMode || "public",
+    teams: accessPolicyMode === "public" ? [] : accessPolicyTeams || [],
+    cutoffDate:
+      accessPolicyMode === "public_until"
+        ? accessPolicyCutoffDate || null
+        : null,
+  };
+
+  const payload = {
+    ...sourceData,
+    media: credentialType,
+    accessPolicy,
+  };
+
+  if (!source) {
+    doCreateSource.mutate(payload);
+    return;
   }
+
+  doEditSource.mutate({ ...payload, _id: source._id });
+}
 
   const doCreateSource = useMutation(newSource, {
     onSuccess: () => {
@@ -117,6 +248,7 @@ const CreateEditSourceForm = ({ source, onClose }: IProps) => {
         credentials: source?.credentials._id || defaultCredential?._id,
         sourceURL: source?.url || "",
         url: "https://www.junkipedia.com/",
+        ...sourceAccessInitialValues,
       }}
       schema={JunkipediaSchema}
       onSubmit={(values: IJunkipediaSchema) => {
@@ -137,6 +269,7 @@ const CreateEditSourceForm = ({ source, onClose }: IProps) => {
         label={"API Credentials"}
         name={"credentials"}
       />
+      <SourceAccessPolicyFields teams={teams} />
     </FormikWithSchema>
   );
 
@@ -159,6 +292,7 @@ const CreateEditSourceForm = ({ source, onClose }: IProps) => {
         credentials: source?.credentials._id || defaultCredential?._id,
         sourceURL: source?.url || "",
         url: "",
+        ...sourceAccessInitialValues,
       }}
       schema={telegramBotSchema}
       onSubmit={(values: ITelegramBotSchema) => {
@@ -202,6 +336,7 @@ const CreateEditSourceForm = ({ source, onClose }: IProps) => {
         credentials: source?.credentials._id || defaultCredential?._id,
         sourceURL: source?.url || "",
         url: "",
+        ...sourceAccessInitialValues,
       }}
       schema={telegramUserSchema}
       onSubmit={(values: ITelegramUserSchema) => {
@@ -232,6 +367,7 @@ const CreateEditSourceForm = ({ source, onClose }: IProps) => {
           multiple entries with commas.
         </p>
       </div>
+      <SourceAccessPolicyFields teams={teams} />
     </FormikWithSchema>
   );
 
@@ -253,6 +389,7 @@ const CreateEditSourceForm = ({ source, onClose }: IProps) => {
         credentials: source?.credentials._id || defaultCredential?._id,
         sourceURL: source?.url || "",
         url: "",
+        ...sourceAccessInitialValues,
       }}
       schema={iodaSchema}
       onSubmit={(values: IodaSchema) => {
@@ -269,6 +406,7 @@ const CreateEditSourceForm = ({ source, onClose }: IProps) => {
         label={"Two-Letter Country Code"}
         name={"keywords"}
       />
+      <SourceAccessPolicyFields teams={teams} />
     </FormikWithSchema>
   );
 
@@ -289,6 +427,7 @@ const CreateEditSourceForm = ({ source, onClose }: IProps) => {
         credentials: source?.credentials._id || defaultCredential?._id,
         sourceURL: source?.url || "",
         url: "",
+        ...sourceAccessInitialValues,
       }}
       schema={cloudflareSchema}
       onSubmit={(values: CloudflareSchema) => {
@@ -305,6 +444,7 @@ const CreateEditSourceForm = ({ source, onClose }: IProps) => {
         label={"Two-Letter Country Code"}
         name={"keywords"}
       />
+      <SourceAccessPolicyFields teams={teams} />
     </FormikWithSchema>
   );
 
@@ -351,6 +491,7 @@ const CreateEditSourceForm = ({ source, onClose }: IProps) => {
         credentials: source?.credentials._id || defaultCredential?._id,
         sourceURL: source?.url || "",
         url: "",
+        ...sourceAccessInitialValues,
       }}
       schema={mastodonSchema}
       onSubmit={(values: IMastodonSchema) => {
@@ -390,6 +531,7 @@ const CreateEditSourceForm = ({ source, onClose }: IProps) => {
         label={"Mastodon Credentials"}
         name={"credentials"}
       />
+      <SourceAccessPolicyFields teams={teams} />
     </FormikWithSchema>
   );
 

--- a/src/pages/Settings/team/TeamDetails.tsx
+++ b/src/pages/Settings/team/TeamDetails.tsx
@@ -1,16 +1,23 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useParams } from "react-router-dom";
 
-import { getTeam } from "../../../api/teams";
-import type { TeamMember } from "../../../api/teams/types";
+import { addTeamMember, getTeam, removeTeamMember } from "../../../api/teams";
+import { getManageableUsers } from "../../../api/users";
+import type { TeamMember, TeamDetailResponse } from "../../../api/teams/types";
 import PlaceholderDiv from "../../../components/PlaceholderDiv";
+
+import { useState } from "react";
 
 const MemberList = ({
   title,
   members,
+  onRemove,
+  removingUserId,
 }: {
   title: string;
   members: TeamMember[];
+  onRemove?: (userId: string) => void;
+  removingUserId?: string;
 }) => {
   return (
     <div className='bg-white dark:bg-gray-800 rounded-xl border border-slate-300 overflow-hidden'>
@@ -22,7 +29,9 @@ const MemberList = ({
         members.map((member) => (
           <article
             key={member._id}
-            className='grid grid-cols-3 px-3 py-3 border-b border-slate-200 last:border-b-0 items-center'
+            className={`grid ${
+              onRemove ? "grid-cols-[1fr_1fr_120px_90px]" : "grid-cols-3"
+            } px-3 py-3 border-b border-slate-200 last:border-b-0 items-center gap-2`}
           >
             <p className='font-medium'>
               {member.displayName || member.username}
@@ -31,6 +40,16 @@ const MemberList = ({
               {member.email}
             </p>
             <p className='text-sm'>{member.role}</p>
+            {onRemove && (
+            <button
+             type='button'
+              className='text-sm text-red-700 hover:underline disabled:opacity-50'
+              disabled={removingUserId === member._id}
+              onClick={() => onRemove(member._id)}
+            >
+              Remove
+            </button>
+          )}
           </article>
         ))
       ) : (
@@ -42,17 +61,57 @@ const MemberList = ({
   );
 };
 
-const TeamDetails = () => {
-  const params = useParams();
+interface IProps {
+  session?: {
+    role?: string;
+  };
+}
 
-  const { data, isLoading } = useQuery(["teams", params.id], () => {
+const TeamDetails = ({ session }: IProps) => {
+  const params = useParams();
+  const queryClient = useQueryClient();
+  const [selectedUserId, setSelectedUserId] = useState("");
+  const [selectedRole, setSelectedRole] = useState("viewer");
+  const [removingUserId, setRemovingUserId] = useState<string | undefined>();
+  const { data: users } = useQuery(["users", "manageable"], getManageableUsers);
+  const doAddMember = useMutation(addTeamMember, {
+  onSuccess: (updatedTeam: TeamDetailResponse) => {
+    queryClient.setQueryData(["teams", params.id], updatedTeam);
+    queryClient.invalidateQueries(["users"]);
+    queryClient.invalidateQueries(["users", "manageable"]);
+    setSelectedUserId("");
+    setSelectedRole("viewer");
+  },
+});
+
+const doRemoveMember = useMutation(removeTeamMember, {
+  onMutate: (variables) => {
+    setRemovingUserId(variables.userId);
+  },
+  onSuccess: (updatedTeam: TeamDetailResponse) => {
+    queryClient.setQueryData(["teams", params.id], updatedTeam);
+    queryClient.invalidateQueries(["users"]);
+    queryClient.invalidateQueries(["users", "manageable"]);
+  },
+  onSettled: () => {
+    setRemovingUserId(undefined);
+  },
+});
+
+const { data, isLoading } = useQuery(["teams", params.id], () => {
     if (params.id) return getTeam(params.id);
     return undefined;
   });
 
-  const members = data?.members || [];
+const members = data?.members || [];
+
+const existingMemberIds = new Set(members.map((member) => member._id));
+
+const availableUsers =
+  users?.filter((user) => !existingMemberIds.has(user._id)) || [];
 
   const teamLeads = members.filter((member) => member.role === "team_lead");
+  const isTeamLead = session?.role === "team_lead";
   const monitors = members.filter((member) => member.role === "monitor");
   const viewers = members.filter((member) => member.role === "viewer");
   const admins = members.filter((member) => member.role === "admin");
@@ -70,6 +129,11 @@ const TeamDetails = () => {
         >
           Back to Teams
         </Link>
+        {isTeamLead && (
+  <p className='text-sm text-slate-600 dark:text-gray-300 mt-2'>
+    Viewing team membership as a team lead.
+  </p>
+)}
       </div>
 
       <PlaceholderDiv loading={isLoading}>
@@ -89,11 +153,92 @@ const TeamDetails = () => {
             </span>
           </div>
         </div>
+        <div className='bg-white dark:bg-gray-800 rounded-xl border border-slate-300 p-3 mb-4'>
+  <h3 className='text-xl font-medium mb-2'>Add team member</h3>
+
+  <div className='grid grid-cols-1 md:grid-cols-[1fr_180px_120px] gap-2 items-end'>
+    <label className='flex flex-col gap-1 text-sm'>
+      <span className='font-medium'>User</span>
+      <select
+        className='px-3 py-2 rounded border border-slate-300 dark:bg-gray-700'
+        value={selectedUserId}
+        onChange={(event) => setSelectedUserId(event.target.value)}
+      >
+        <option value=''>Select user</option>
+        {availableUsers.map((user) => (
+          <option key={user._id} value={user._id}>
+            {user.displayName || user.username} ({user.email})
+          </option>
+        ))}
+      </select>
+    </label>
+
+    <label className='flex flex-col gap-1 text-sm'>
+      <span className='font-medium'>Role</span>
+      <select
+        className='px-3 py-2 rounded border border-slate-300 dark:bg-gray-700'
+        value={selectedRole}
+        onChange={(event) => setSelectedRole(event.target.value)}
+      >
+        <option value='viewer'>Viewer</option>
+        <option value='monitor'>Monitor</option>
+        <option value='team_lead'>Team Lead</option>
+      </select>
+    </label>
+
+    <button
+      type='button'
+      className='px-3 py-2 rounded bg-lime-700 text-white disabled:opacity-50'
+      disabled={!params.id || !selectedUserId || doAddMember.isLoading}
+      onClick={() => {
+        if (!params.id || !selectedUserId) return;
+
+        doAddMember.mutate({
+          teamId: params.id,
+          userId: selectedUserId,
+          role: selectedRole,
+        });
+      }}
+    >
+      Add
+    </button>
+  </div>
+
+  <p className='text-xs text-slate-500 dark:text-gray-400 mt-2'>
+    Adding a user as Team Lead changes their global role to team_lead.
+  </p>
+</div>
 
         <div className='flex flex-col gap-4'>
-          <MemberList title='Team Leads' members={teamLeads} />
-          <MemberList title='Monitors' members={monitors} />
-          <MemberList title='Viewers' members={viewers} />
+         <MemberList
+  title={`Team Leads (${teamLeads.length})`}
+  members={teamLeads}
+  removingUserId={removingUserId}
+  onRemove={(userId) => {
+    if (!params.id) return;
+    doRemoveMember.mutate({ teamId: params.id, userId });
+  }}
+/>
+
+<MemberList
+  title={`Monitors (${monitors.length})`}
+  members={monitors}
+  removingUserId={removingUserId}
+  onRemove={(userId) => {
+    if (!params.id) return;
+    doRemoveMember.mutate({ teamId: params.id, userId });
+  }}
+/>
+
+<MemberList
+  title={`Viewers (${viewers.length})`}
+  members={viewers}
+  removingUserId={removingUserId}
+  onRemove={(userId) => {
+    if (!params.id) return;
+    doRemoveMember.mutate({ teamId: params.id, userId });
+  }}
+/>
 
           {admins.length > 0 && (
             <MemberList title='Admins' members={admins} />

--- a/src/pages/Settings/team/TeamsIndex.tsx
+++ b/src/pages/Settings/team/TeamsIndex.tsx
@@ -2,14 +2,25 @@ import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { createTeam, deleteTeam, getTeams } from "../../../api/teams";
+
 import { Link } from "react-router-dom";
 import AggieButton from "../../../components/AggieButton";
 import PlaceholderDiv from "../../../components/PlaceholderDiv";
 
-const TeamsIndex = () => {
+
+interface IProps {
+  session?: {
+    role?: string;
+  };
+}
+
+const TeamsIndex = ({ session }: IProps) => {
+
+  const isAdmin = session?.role === "admin";
+  const isTeamLead = session?.role === "team_lead";
   const queryClient = useQueryClient();
 
-  const { data: teams, isLoading } = useQuery(["teams"], getTeams);
+const { data: teams, isLoading } = useQuery(["teams", "all"], getTeams);
 
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");


### PR DESCRIPTION
Added more visible team management work:
- Team leads can now access the Teams page
- Team leads can view/create/delete teams during this stage of the access-control buildout
- Team detail pages are being expanded toward direct membership management

Open design note:
- The current app has `team_lead` as a global user role. We may want to separate global role from per-team leadership later so someone can lead one team without becoming a global team lead everywhere.


-added initial steps for source access control in creation
-created cutoff date for source creation for public/team based visibility
-added helpers for source access control